### PR TITLE
Daily account snapshot

### DIFF
--- a/cmd/bdjuno/main.go
+++ b/cmd/bdjuno/main.go
@@ -8,8 +8,11 @@ import (
 	"github.com/desmos-labs/juno/config"
 	"github.com/desmos-labs/juno/executor"
 	"github.com/desmos-labs/juno/parse"
+	"github.com/desmos-labs/juno/parse/worker"
 	"github.com/desmos-labs/juno/version"
 	"github.com/forbole/bdjuno/database"
+	"github.com/forbole/bdjuno/x/auth"
+	"github.com/forbole/bdjuno/x/bank"
 	"github.com/forbole/bdjuno/x/staking"
 	"github.com/go-co-op/gocron"
 )
@@ -53,12 +56,15 @@ func SetupConfig(prefix string) func(cfg *sdk.Config) {
 }
 
 func SetupModules() {
-	// Create the scheduler
-	scheduler := gocron.NewScheduler(time.UTC)
+	// Register genesis handlers
+	worker.RegisterGenesisHandler(auth.GenesisHandler)
+
+	// Register msg handlers
+	worker.RegisterMsgHandler(bank.MsgHandler)
 
 	// Register periodic operations
+	scheduler := gocron.NewScheduler(time.UTC)
 	parse.RegisterAdditionalOperation(staking.PeriodicStakingOperations(scheduler))
-
-	// Start the scheduler
+	parse.RegisterAdditionalOperation(auth.PeriodicAuthOperations(scheduler))
 	scheduler.StartAsync()
 }

--- a/database/auth.go
+++ b/database/auth.go
@@ -1,0 +1,95 @@
+package database
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/lib/pq"
+)
+
+type AccountRow struct {
+	Address   string    `db:"address"`
+	Coins     DbCoin    `db:"coins"`
+	Height    int64     `db:"height"`
+	Timestamp time.Time `db:"height"`
+}
+
+// DbCoin represents the information stored inside the database about a single coin
+type DbCoin struct {
+	Denom  string
+	Amount int64
+}
+
+// Value implements driver.Valuer
+func (coin *DbCoin) Value() (driver.Value, error) {
+	return fmt.Sprintf("(%s,%d)", coin.Denom, coin.Amount), nil
+}
+
+// DbCoins represents an array of coins
+type DbCoins []*DbCoin
+
+// NewDbCoins build a new DbCoins object starting from an array of coins
+func NewDbCoins(coins sdk.Coins) DbCoins {
+	dbCoins := make([]*DbCoin, 0)
+	for _, coin := range coins {
+		dbCoins = append(dbCoins, &DbCoin{Amount: coin.Amount.Int64(), Denom: coin.Denom})
+	}
+	return dbCoins
+}
+
+// SaveAccount saves the given account information for the given block height and timestamp
+func (db BigDipperDb) SaveAccount(account exported.Account, height int64, timestamp time.Time) error {
+	statement := `INSERT INTO account (address, coins, height, timestamp) 
+				  VALUES ($1, $2::coin[], $3, $4) 
+				  ON CONFLICT DO NOTHING`
+
+	_, err := db.Sql.Exec(statement,
+		account.GetAddress().String(), pq.Array(NewDbCoins(account.GetCoins())), height, timestamp)
+	return err
+}
+
+// SaveAccount saves the given accounts information for the given block height and timestamp
+func (db BigDipperDb) SaveAccounts(accounts []exported.Account, height int64, timestamp time.Time) error {
+	var insertParams []interface{}
+
+	queryInsert := "INSERT INTO account (address, coins, height, timestamp) VALUES "
+	for i, account := range accounts {
+		p1 := i * 4 // Starting position for insert params
+
+		queryInsert += fmt.Sprintf("($%d,$%d,$%d,$%d),", p1+1, p1+2, p1+3, p1+4)
+		insertParams = append(insertParams,
+			account.GetAddress().String(), pq.Array(NewDbCoins(account.GetCoins())), height, timestamp)
+	}
+
+	queryInsert = queryInsert[:len(queryInsert)-1] // Remove trailing ","
+	queryInsert += " ON CONFLICT DO NOTHING"
+	_, err := db.Sql.Exec(queryInsert, insertParams...)
+	return err
+}
+
+// GetPollByPostID returns the poll row associated to the post having the specified id.
+// If the post with the same id has no poll associated to it, nil is returned instead.
+func (db BigDipperDb) GetAccounts() ([]sdk.AccAddress, error) {
+	sqlStmt := `SELECT DISTINCT address from account`
+
+	var rows []AccountRow
+	err := db.sqlx.Select(&rows, sqlStmt)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses := make([]sdk.AccAddress, len(rows))
+	for index, row := range rows {
+		address, err := sdk.AccAddressFromBech32(row.Address)
+		if err != nil {
+			return nil, err
+		}
+
+		addresses[index] = address
+	}
+
+	return addresses, nil
+}

--- a/database/cosmos_extensions.go
+++ b/database/cosmos_extensions.go
@@ -13,19 +13,18 @@ func (db BigDipperDb) SaveValidators(validators []staking.Validator) error {
 
 	queryInsert := "INSERT INTO validator (consensus_address, consensus_pubkey) VALUES "
 	for i, result := range validators {
-		p1 := i * 2 // starting position for insert params
+		p1 := i * 2 // Starting position for insert params
 
-		queryInsert += fmt.Sprintf("($%d,$%d),", p1+1, p1+2)
-
-		key, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, result.ConsPubKey)
+		publicKey, err := sdk.Bech32ifyPubKey(sdk.Bech32PubKeyTypeConsPub, result.ConsPubKey)
 		if err != nil {
 			return err
 		}
 
-		insertParams = append(insertParams, result.ConsAddress().String(), key)
+		queryInsert += fmt.Sprintf("($%d,$%d),", p1+1, p1+2)
+		insertParams = append(insertParams, result.ConsAddress().String(), publicKey)
 	}
 
-	queryInsert = queryInsert[:len(queryInsert)-1] // remove trailing ","
+	queryInsert = queryInsert[:len(queryInsert)-1] // Remove trailing ","
 	queryInsert += " ON CONFLICT DO NOTHING"
 	_, err := db.Sql.Exec(queryInsert, insertParams...)
 	return err

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,7 @@ require (
 	github.com/desmos-labs/juno v0.0.0-20200615084022-e95f19b114df
 	github.com/go-co-op/gocron v0.2.0
 	github.com/jmoiron/sqlx v1.2.1-0.20200324155115-ee514944af4b
+	github.com/lib/pq v1.3.0
 	github.com/rs/zerolog v1.18.0
+	github.com/tendermint/tendermint v0.33.3
 )

--- a/schema/auth.sql
+++ b/schema/auth.sql
@@ -1,0 +1,14 @@
+CREATE TYPE COIN AS
+(
+    denom  TEXT,
+    amount BIGINT
+);
+
+CREATE TABLE account
+(
+    address   TEXT                        NOT NULL,
+    coins     COIN[]                      NOT NULL DEFAULT '{}',
+    height    BIGINT                      NOT NULL,
+    timestamp TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+    PRIMARY KEY (address, height)
+)

--- a/schema/auth.sql
+++ b/schema/auth.sql
@@ -6,7 +6,12 @@ CREATE TYPE COIN AS
 
 CREATE TABLE account
 (
-    address   TEXT                        NOT NULL,
+    address TEXT NOT NULL PRIMARY KEY
+);
+
+CREATE TABLE balance
+(
+    address   TEXT                        NOT NULL REFERENCES account (address),
     coins     COIN[]                      NOT NULL DEFAULT '{}',
     height    BIGINT                      NOT NULL,
     timestamp TIMESTAMP WITHOUT TIME ZONE NOT NULL,

--- a/x/auth/accounts.go
+++ b/x/auth/accounts.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/desmos-labs/juno/parse/client"
+	"github.com/forbole/bdjuno/database"
+	"github.com/rs/zerolog/log"
+	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
+)
+
+// RefreshAccounts takes the given addresses and for each one queries the LCD
+// retrieving the latest balance storing it inside the database.
+func RefreshAccounts(
+	addresses []sdk.AccAddress, height int64, timestamp time.Time, cp client.ClientProxy, db database.BigDipperDb,
+) error {
+	// Get all the accounts information
+	var accounts []exported.Account
+	for _, address := range addresses {
+		endpoint := fmt.Sprintf("/auth/accounts/%s?height=%d", address.String(), height)
+
+		var account exported.Account
+		_, err := cp.QueryLCDWithHeight(endpoint, &account)
+		if err != nil {
+			return err
+		}
+
+		accounts = append(accounts, account)
+	}
+
+	return db.SaveAccounts(accounts, height, timestamp)
+}
+
+// updateAccounts gets all the accounts stored inside the database, and refreshes their
+// balances by fetching the LCD endpoint.
+func updateAccounts(cp client.ClientProxy, db database.BigDipperDb) error {
+	log.Debug().Str("module_name", "auth").Msg("updating accounts")
+
+	var block tmctypes.ResultBlock
+	err := cp.QueryLCD("/blocks/latest", &block)
+	if err != nil {
+		return err
+	}
+
+	addresses, err := db.GetAccounts()
+	if err != nil {
+		return err
+	}
+
+	return RefreshAccounts(addresses, block.Block.Height, block.Block.Time, cp, db)
+}

--- a/x/auth/genesis_handler.go
+++ b/x/auth/genesis_handler.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/auth"
+	"github.com/cosmos/cosmos-sdk/x/auth/exported"
+	"github.com/desmos-labs/juno/parse/worker"
+	"github.com/forbole/bdjuno/database"
+	"github.com/rs/zerolog/log"
+	"github.com/tendermint/tendermint/types"
+)
+
+// GenesisHandler handles the genesis state of the x/auth module in order to store the initial values
+// of the different accounts.
+func GenesisHandler(codec *codec.Codec, genDoc *types.GenesisDoc, appState map[string]json.RawMessage, w worker.Worker) error {
+	log.Debug().Str("module", "auth").Msg("parsing genesis")
+
+	db, ok := w.Db.(database.BigDipperDb)
+	if !ok {
+		return fmt.Errorf("given database instance is not a BigDipperDb")
+	}
+
+	var authState auth.GenesisState
+	if err := codec.UnmarshalJSON(appState[auth.ModuleName], &authState); err != nil {
+		return err
+	}
+
+	// Store the accounts
+	accounts := make([]exported.Account, len(authState.Accounts))
+	for index, account := range authState.Accounts {
+		accounts[index] = account.(exported.Account)
+	}
+	if err := db.SaveAccounts(accounts, 0, genDoc.GenesisTime); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/x/auth/periodic_operations.go
+++ b/x/auth/periodic_operations.go
@@ -1,4 +1,4 @@
-package staking
+package auth
 
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -12,10 +12,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// PeriodicStakingOperations returns the AdditionalOperation that periodically runs fetches from
+// PeriodicAuthOperations returns the AdditionalOperation that periodically runs fetches from
 // the LCD to make sure that constantly changing data are synced properly.
-func PeriodicStakingOperations(scheduler *gocron.Scheduler) parse.AdditionalOperation {
-	log.Debug().Str("module", "staking").Msg("setting up 15 secs periodic task")
+func PeriodicAuthOperations(scheduler *gocron.Scheduler) parse.AdditionalOperation {
+	log.Debug().Str("module", "auth").Msg("setting up periodic tasks")
 
 	return func(_ config.Config, _ *codec.Codec, cp client.ClientProxy, db db.Database) error {
 		bdDatabase, ok := db.(database.BigDipperDb)
@@ -23,17 +23,9 @@ func PeriodicStakingOperations(scheduler *gocron.Scheduler) parse.AdditionalOper
 			log.Fatal().Msg("given database instance is not a BigDipperDb")
 		}
 
-		// Setup a cron job to run every 15 seconds
-		if _, err := scheduler.Every(15).Second().Do(func() {
-			utils.WatchMethod(func() error { return updateStakingPool(cp, bdDatabase) })
-			utils.WatchMethod(func() error { return updateValidatorsUptime(cp, bdDatabase) })
-		}); err != nil {
-			return err
-		}
-
 		// Setup a cron job to run every midnight
 		if _, err := scheduler.Every(1).Day().At("00:00").Do(func() {
-			utils.WatchMethod(func() error { return updateStakingPool(cp, bdDatabase) })
+			utils.WatchMethod(func() error { return updateAccounts(cp, bdDatabase) })
 		}); err != nil {
 			return err
 		}

--- a/x/auth/periodic_operations.go
+++ b/x/auth/periodic_operations.go
@@ -24,7 +24,7 @@ func PeriodicAuthOperations(scheduler *gocron.Scheduler) parse.AdditionalOperati
 		}
 
 		// Setup a cron job to run every midnight
-		if _, err := scheduler.Every(1).Day().At("00:00").Do(func() {
+		if _, err := scheduler.Every(1).Day().At("00:00").StartImmediately().Do(func() {
 			utils.WatchMethod(func() error { return updateAccounts(cp, bdDatabase) })
 		}); err != nil {
 			return err

--- a/x/bank/msghandler.go
+++ b/x/bank/msghandler.go
@@ -1,0 +1,53 @@
+package bank
+
+import (
+	"fmt"
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/bank"
+	"github.com/desmos-labs/juno/parse/worker"
+	"github.com/desmos-labs/juno/types"
+	"github.com/forbole/bdjuno/database"
+	"github.com/forbole/bdjuno/x/auth"
+	"github.com/rs/zerolog/log"
+)
+
+func MsgHandler(tx types.Tx, index int, msg sdk.Msg, w worker.Worker) error {
+	log.Info().Str("tx_hash", tx.TxHash).Int("msg_index", index).
+		Str("msg_type", msg.Type()).Msg("found message")
+
+	if len(tx.Logs) == 0 {
+		log.Info().Str("tx_hash", tx.TxHash).Int("msg_index", index).
+			Msg("skipping message as it was not successful")
+		return nil
+	}
+
+	db, ok := w.Db.(database.BigDipperDb)
+	if !ok {
+		return fmt.Errorf("given database instance is not a BigDipperDb")
+	}
+
+	timestamp, err := time.Parse("2006-01-02T15:04:05Z", tx.Timestamp)
+	if err != nil {
+		return err
+	}
+
+	switch bankMSg := msg.(type) {
+	case bank.MsgSend:
+		accounts := []sdk.AccAddress{bankMSg.FromAddress, bankMSg.FromAddress}
+		return auth.RefreshAccounts(accounts, tx.Height, timestamp, w.ClientProxy, db)
+	case bank.MsgMultiSend:
+		var accounts []sdk.AccAddress
+		for _, input := range bankMSg.Inputs {
+			accounts = append(accounts, input.Address)
+		}
+		for _, output := range bankMSg.Outputs {
+			accounts = append(accounts, output.Address)
+		}
+
+		return auth.RefreshAccounts(accounts, tx.Height, timestamp, w.ClientProxy, db)
+	}
+
+	return nil
+}

--- a/x/staking/periodic_operations.go
+++ b/x/staking/periodic_operations.go
@@ -1,0 +1,43 @@
+package staking
+
+import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/desmos-labs/juno/config"
+	"github.com/desmos-labs/juno/db"
+	"github.com/desmos-labs/juno/parse"
+	"github.com/desmos-labs/juno/parse/client"
+	"github.com/forbole/bdjuno/database"
+	"github.com/forbole/bdjuno/x/utils"
+	"github.com/go-co-op/gocron"
+	"github.com/rs/zerolog/log"
+)
+
+// PeriodicStakingOperations returns the AdditionalOperation that periodically runs fetches from
+// the LCD to make sure that constantly changing data are synced properly.
+func PeriodicStakingOperations(scheduler *gocron.Scheduler) parse.AdditionalOperation {
+	log.Debug().Str("module", "staking").Msg("setting up periodic tasks")
+
+	return func(_ config.Config, _ *codec.Codec, cp client.ClientProxy, db db.Database) error {
+		bdDatabase, ok := db.(database.BigDipperDb)
+		if !ok {
+			log.Fatal().Msg("given database instance is not a BigDipperDb")
+		}
+
+		// Setup a cron job to run every 15 seconds
+		if _, err := scheduler.Every(15).Second().StartImmediately().Do(func() {
+			utils.WatchMethod(func() error { return updateStakingPool(cp, bdDatabase) })
+			utils.WatchMethod(func() error { return updateValidatorsUptime(cp, bdDatabase) })
+		}); err != nil {
+			return err
+		}
+
+		// Setup a cron job to run every midnight
+		if _, err := scheduler.Every(1).Day().At("00:00").Do(func() {
+			utils.WatchMethod(func() error { return updateStakingPool(cp, bdDatabase) })
+		}); err != nil {
+			return err
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
This PR adds the daily snapshot of the accounts balances (closes #7). 

The fetch is done by: 

- parsing the genesis data to get all the genesis accounts;
- parsing `MsgSend` and `MsgMultiSend` to get new accounts as soon as some tokens are sent to them; 
- querying the LCD at the midnight of every day per each account present inside the database, storing their data inside a database table