### PR TITLE
Improvements

### DIFF
--- a/database/auth_test.go
+++ b/database/auth_test.go
@@ -2,7 +2,7 @@ package database_test
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 
 	"github.com/forbole/bdjuno/types"
 
@@ -13,7 +13,7 @@ func (suite *DbTestSuite) TestSaveAccount() {
 	address, err := sdk.AccAddressFromBech32("cosmos140xsjjg6pwkjp0xjz8zru7ytha60l5aee9nlf7")
 	suite.Require().NoError(err)
 
-	account := authtypes.NewBaseAccountWithAddress(address)
+	account := authttypes.NewBaseAccountWithAddress(address)
 
 	// ------------------------------
 	// --- Save the data

--- a/database/schema/08-gov.sql
+++ b/database/schema/08-gov.sql
@@ -61,3 +61,27 @@ CREATE TABLE proposal_tally_result
 );
 CREATE INDEX proposal_tally_result_proposal_id_index ON proposal_tally_result (proposal_id);
 CREATE INDEX proposal_tally_result_height_index ON proposal_tally_result (height);
+
+CREATE TABLE proposal_staking_pool_snapshot
+(
+    proposal_id       INTEGER REFERENCES proposal (id) PRIMARY KEY,
+    bonded_tokens     BIGINT NOT NULL,
+    not_bonded_tokens BIGINT NOT NULL,
+    height            BIGINT NOT NULL,
+    CONSTRAINT unique_staking_pool_snapshot UNIQUE (proposal_id)
+);
+CREATE INDEX proposal_staking_pool_snapshot_proposal_id_index ON proposal_staking_pool_snapshot (proposal_id);
+
+CREATE TABLE proposal_validator_status_snapshot
+(
+    id                SERIAL PRIMARY KEY NOT NULL,
+    proposal_id       INTEGER REFERENCES proposal (id),
+    validator_address TEXT               NOT NULL REFERENCES validator (consensus_address),
+    voting_power      BIGINT             NOT NULL,
+    status            INT                NOT NULL,
+    jailed            BOOLEAN            NOT NULL,
+    height            BIGINT             NOT NULL,
+    CONSTRAINT unique_validator_status_snapshot UNIQUE (proposal_id, validator_address)
+);
+CREATE INDEX proposal_validator_status_snapshot_proposal_id_index ON proposal_validator_status_snapshot (proposal_id);
+CREATE INDEX proposal_validator_status_snapshot_validator_address_index ON proposal_validator_status_snapshot (validator_address);

--- a/database/staking_pool.go
+++ b/database/staking_pool.go
@@ -5,7 +5,7 @@ import (
 )
 
 // SaveStakingPool allows to save for the given height the given stakingtypes pool
-func (db *Db) SaveStakingPool(pool types.Pool) error {
+func (db *Db) SaveStakingPool(pool *types.Pool) error {
 	stmt := `
 INSERT INTO staking_pool (bonded_tokens, not_bonded_tokens, height) 
 VALUES ($1, $2, $3)

--- a/database/staking_validators.go
+++ b/database/staking_validators.go
@@ -239,7 +239,7 @@ func (db *Db) getValidatorDescription(address sdk.ConsAddress) (*types.Validator
 	return &description, true
 }
 
-// ________________________________________________
+// --------------------------------------------------------------------------------------------------------------------
 
 // SaveValidatorCommission saves a single validator commission.
 // It assumes that the delegator address is already present inside the
@@ -301,7 +301,7 @@ func (db *Db) getValidatorCommission(address sdk.ConsAddress) (*dbtypes.Validato
 	return &rows[0], true
 }
 
-// ________________________________________________
+// --------------------------------------------------------------------------------------------------------------------
 
 // SaveValidatorsVotingPowers saves the given validator voting powers.
 // It assumes that the delegator address is already present inside the
@@ -328,7 +328,7 @@ WHERE validator_voting_power.height <= excluded.height`
 	return err
 }
 
-//---------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 
 // SaveValidatorsStatuses save validator jail and status in the given height and timestamp
 func (db *Db) SaveValidatorsStatuses(statuses []types.ValidatorStatus) error {

--- a/database/types/gov.go
+++ b/database/types/gov.go
@@ -177,3 +177,47 @@ func (w DepositRow) Equals(v DepositRow) bool {
 		w.Amount.Equal(&v.Amount) &&
 		w.Height == v.Height
 }
+
+// --------------------------------------------------------------------------------------------------------------------
+
+type ProposalStakingPoolSnapshotRow struct {
+	ProposalID      uint64 `db:"proposal_id"`
+	BondedTokens    int64  `db:"bonded_tokens"`
+	NotBondedTokens int64  `db:"not_bonded_tokens"`
+	Height          int64  `db:"height"`
+}
+
+func NewProposalStakingPoolSnapshotRow(proposalID uint64, bondedTokens, notBondedTokens, height int64) ProposalStakingPoolSnapshotRow {
+	return ProposalStakingPoolSnapshotRow{
+		ProposalID:      proposalID,
+		BondedTokens:    bondedTokens,
+		NotBondedTokens: notBondedTokens,
+		Height:          height,
+	}
+}
+
+// --------------------------------------------------------------------------------------------------------------------
+
+type ProposalValidatorVotingPowerSnapshotRow struct {
+	ID               int64  `db:"id"`
+	ProposalID       int64  `db:"proposal_id"`
+	ValidatorAddress string `db:"validator_address"`
+	VotingPower      int64  `db:"voting_power"`
+	Status           int    `db:"status"`
+	Jailed           bool   `db:"jailed"`
+	Height           int64  `db:"height"`
+}
+
+func NewProposalValidatorVotingPowerSnapshotRow(
+	id int64, proposalID int64, validatorAddr string, votingPower int64, status int, jailed bool, height int64,
+) ProposalValidatorVotingPowerSnapshotRow {
+	return ProposalValidatorVotingPowerSnapshotRow{
+		ID:               id,
+		ProposalID:       proposalID,
+		ValidatorAddress: validatorAddr,
+		VotingPower:      votingPower,
+		Status:           status,
+		Jailed:           jailed,
+		Height:           height,
+	}
+}

--- a/modules/auth/handle_fast_sync.go
+++ b/modules/auth/handle_fast_sync.go
@@ -9,11 +9,11 @@ import (
 	"github.com/forbole/bdjuno/types"
 
 	"github.com/cosmos/cosmos-sdk/types/query"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 // FastSync downloads the x/auth state at the given height, and stores it inside the database
-func FastSync(height int64, client authtypes.QueryClient, db *database.Db) error {
+func FastSync(height int64, client authttypes.QueryClient, db *database.Db) error {
 	err := updateAccounts(height, client, db)
 	if err != nil {
 		return err
@@ -23,7 +23,7 @@ func FastSync(height int64, client authtypes.QueryClient, db *database.Db) error
 }
 
 // updateAccounts downloads all the accounts at the given height, and stores them inside the database
-func updateAccounts(height int64, authClient authtypes.QueryClient, db *database.Db) error {
+func updateAccounts(height int64, authClient authttypes.QueryClient, db *database.Db) error {
 	header := client.GetHeightRequestHeader(height)
 
 	var nextKey []byte
@@ -31,7 +31,7 @@ func updateAccounts(height int64, authClient authtypes.QueryClient, db *database
 	for !stop {
 		res, err := authClient.Accounts(
 			context.Background(),
-			&authtypes.QueryAccountsRequest{
+			&authttypes.QueryAccountsRequest{
 				Pagination: &query.PageRequest{
 					Key:   nextKey,
 					Limit: 100, // Query 100 accounts at time
@@ -46,7 +46,7 @@ func updateAccounts(height int64, authClient authtypes.QueryClient, db *database
 		var accounts = make([]types.Account, len(res.Accounts))
 		for index, acc := range res.Accounts {
 			accounts[index] = types.NewAccount(
-				acc.GetCachedValue().(authtypes.AccountI).GetAddress().String(),
+				acc.GetCachedValue().(authttypes.AccountI).GetAddress().String(),
 			)
 		}
 

--- a/modules/auth/module.go
+++ b/modules/auth/module.go
@@ -7,12 +7,10 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/desmos-labs/juno/modules"
 	"github.com/desmos-labs/juno/modules/messages"
 	juno "github.com/desmos-labs/juno/types"
-	"google.golang.org/grpc"
-
-	"github.com/desmos-labs/juno/modules"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -27,19 +25,20 @@ var (
 type Module struct {
 	messagesParser messages.MessageAddressesParser
 	encodingConfig *params.EncodingConfig
-	authClient     authtypes.QueryClient
+	authClient     authttypes.QueryClient
 	db             *database.Db
 }
 
 // NewModule builds a new Module instance
 func NewModule(
 	messagesParser messages.MessageAddressesParser,
-	encodingConfig *params.EncodingConfig, grpcConnection *grpc.ClientConn, db *database.Db,
+	authClient authttypes.QueryClient,
+	encodingConfig *params.EncodingConfig, db *database.Db,
 ) *Module {
 	return &Module{
 		messagesParser: messagesParser,
 		encodingConfig: encodingConfig,
-		authClient:     authtypes.NewQueryClient(grpcConnection),
+		authClient:     authClient,
 		db:             db,
 	}
 }

--- a/modules/auth/utils/accounts.go
+++ b/modules/auth/utils/accounts.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/rs/zerolog/log"
 
 	"github.com/forbole/bdjuno/database"
@@ -16,15 +16,15 @@ import (
 func GetGenesisAccounts(appState map[string]json.RawMessage, cdc codec.Marshaler) ([]types.Account, error) {
 	log.Debug().Str("module", "auth").Msg("parsing genesis")
 
-	var authState authtypes.GenesisState
-	if err := cdc.UnmarshalJSON(appState[authtypes.ModuleName], &authState); err != nil {
+	var authState authttypes.GenesisState
+	if err := cdc.UnmarshalJSON(appState[authttypes.ModuleName], &authState); err != nil {
 		return nil, err
 	}
 
 	// Store the accounts
 	accounts := make([]types.Account, len(authState.Accounts))
 	for index, account := range authState.Accounts {
-		var accountI authtypes.AccountI
+		var accountI authttypes.AccountI
 		err := cdc.UnpackAny(account, &accountI)
 		if err != nil {
 			return nil, err

--- a/modules/bank/module.go
+++ b/modules/bank/module.go
@@ -9,10 +9,8 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/simapp/params"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	authttypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	"google.golang.org/grpc"
-
 	"github.com/desmos-labs/juno/modules"
 	"github.com/desmos-labs/juno/types"
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
@@ -30,21 +28,22 @@ var (
 type Module struct {
 	messageParser  junomessages.MessageAddressesParser
 	encodingConfig *params.EncodingConfig
-	authClient     authtypes.QueryClient
+	authClient     authttypes.QueryClient
 	bankClient     banktypes.QueryClient
 	db             *database.Db
 }
 
 // NewModule returns a new Module instance
 func NewModule(
-	messageParser junomessages.MessageAddressesParser, encodingConfig *params.EncodingConfig,
-	grpcConnection *grpc.ClientConn, db *database.Db,
+	messageParser junomessages.MessageAddressesParser,
+	authClient authttypes.QueryClient, bankClient banktypes.QueryClient,
+	encodingConfig *params.EncodingConfig, db *database.Db,
 ) *Module {
 	return &Module{
 		messageParser:  messageParser,
 		encodingConfig: encodingConfig,
-		authClient:     authtypes.NewQueryClient(grpcConnection),
-		bankClient:     banktypes.NewQueryClient(grpcConnection),
+		authClient:     authClient,
+		bankClient:     bankClient,
 		db:             db,
 	}
 }

--- a/modules/distribution/module.go
+++ b/modules/distribution/module.go
@@ -3,7 +3,6 @@ package distribution
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
-	"google.golang.org/grpc"
 
 	"github.com/forbole/bdjuno/database"
 
@@ -27,9 +26,9 @@ type Module struct {
 }
 
 // NewModule returns a new Module instance
-func NewModule(grpConnection *grpc.ClientConn, db *database.Db) *Module {
+func NewModule(distrClient distrtypes.QueryClient, db *database.Db) *Module {
 	return &Module{
-		distrClient: distrtypes.NewQueryClient(grpConnection),
+		distrClient: distrClient,
 		db:          db,
 	}
 }

--- a/modules/gov/module.go
+++ b/modules/gov/module.go
@@ -12,10 +12,8 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/cosmos/cosmos-sdk/simapp/params"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"google.golang.org/grpc"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	"github.com/desmos-labs/juno/modules"
 	"github.com/desmos-labs/juno/types"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -38,12 +36,15 @@ type Module struct {
 }
 
 // NewModule returns a new Module instance
-func NewModule(encodingConfig *params.EncodingConfig, grpcConnection *grpc.ClientConn, db *database.Db) *Module {
+func NewModule(
+	bankClient banktypes.QueryClient, govClient govtypes.QueryClient, stakingClient stakingtypes.QueryClient,
+	encodingConfig *params.EncodingConfig, db *database.Db,
+) *Module {
 	return &Module{
 		encodingConfig: encodingConfig,
-		govClient:      govtypes.NewQueryClient(grpcConnection),
-		bankClient:     banktypes.NewQueryClient(grpcConnection),
-		stakingClient:  stakingtypes.NewQueryClient(grpcConnection),
+		govClient:      govClient,
+		bankClient:     bankClient,
+		stakingClient:  stakingClient,
 		db:             db,
 	}
 }

--- a/modules/gov/module.go
+++ b/modules/gov/module.go
@@ -3,6 +3,8 @@ package gov
 import (
 	"encoding/json"
 
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
 
 	"github.com/forbole/bdjuno/database"
@@ -31,6 +33,7 @@ type Module struct {
 	encodingConfig *params.EncodingConfig
 	govClient      govtypes.QueryClient
 	bankClient     banktypes.QueryClient
+	stakingClient  stakingtypes.QueryClient
 	db             *database.Db
 }
 
@@ -40,6 +43,7 @@ func NewModule(encodingConfig *params.EncodingConfig, grpcConnection *grpc.Clien
 		encodingConfig: encodingConfig,
 		govClient:      govtypes.NewQueryClient(grpcConnection),
 		bankClient:     banktypes.NewQueryClient(grpcConnection),
+		stakingClient:  stakingtypes.NewQueryClient(grpcConnection),
 		db:             db,
 	}
 }
@@ -55,8 +59,8 @@ func (m *Module) HandleGenesis(_ *tmtypes.GenesisDoc, appState map[string]json.R
 }
 
 // HandleBlock implements modules.BlockModule
-func (m *Module) HandleBlock(b *tmctypes.ResultBlock, _ []*types.Tx, _ *tmctypes.ResultValidators) error {
-	return HandleBlock(b.Block.Height, m.govClient, m.bankClient, m.db)
+func (m *Module) HandleBlock(b *tmctypes.ResultBlock, _ []*types.Tx, vals *tmctypes.ResultValidators) error {
+	return HandleBlock(b.Block.Height, vals, m.govClient, m.bankClient, m.stakingClient, m.encodingConfig.Marshaler, m.db)
 }
 
 // HandleMsg implements modules.MessageModule

--- a/modules/mint/module.go
+++ b/modules/mint/module.go
@@ -4,7 +4,6 @@ import (
 	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/desmos-labs/juno/modules"
 	"github.com/go-co-op/gocron"
-	"google.golang.org/grpc"
 
 	"github.com/forbole/bdjuno/database"
 )
@@ -18,9 +17,9 @@ type Module struct {
 }
 
 // NewModule returns a new Module instance
-func NewModule(grpcConnection *grpc.ClientConn, db *database.Db) *Module {
+func NewModule(mintClient minttypes.QueryClient, db *database.Db) *Module {
 	return &Module{
-		mintClient: minttypes.NewQueryClient(grpcConnection),
+		mintClient: mintClient,
 		db:         db,
 	}
 }

--- a/modules/slashing/module.go
+++ b/modules/slashing/module.go
@@ -2,7 +2,6 @@ package slashing
 
 import (
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-	"google.golang.org/grpc"
 
 	"github.com/forbole/bdjuno/database"
 
@@ -20,9 +19,9 @@ type Module struct {
 }
 
 // NewModule returns a new Module instance
-func NewModule(grpcConnection *grpc.ClientConn, db *database.Db) *Module {
+func NewModule(slashingClient slashingtypes.QueryClient, db *database.Db) *Module {
 	return &Module{
-		slashingClient: slashingtypes.NewQueryClient(grpcConnection),
+		slashingClient: slashingClient,
 		db:             db,
 	}
 }

--- a/modules/staking/module.go
+++ b/modules/staking/module.go
@@ -8,10 +8,8 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	"github.com/cosmos/cosmos-sdk/simapp/params"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"google.golang.org/grpc"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/desmos-labs/juno/modules"
 	"github.com/desmos-labs/juno/types"
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
@@ -34,11 +32,14 @@ type Module struct {
 }
 
 // NewModule returns a new Module instance
-func NewModule(encodingConfig *params.EncodingConfig, grpcConnection *grpc.ClientConn, db *database.Db) *Module {
+func NewModule(
+	bankClient banktypes.QueryClient, stakingClient stakingtypes.QueryClient,
+	encodingConfig *params.EncodingConfig, db *database.Db,
+) *Module {
 	return &Module{
 		encodingConfig: encodingConfig,
-		stakingClient:  stakingtypes.NewQueryClient(grpcConnection),
-		bankClient:     banktypes.NewQueryClient(grpcConnection),
+		stakingClient:  stakingClient,
+		bankClient:     bankClient,
 		db:             db,
 	}
 }

--- a/modules/staking/utils/staking_pool.go
+++ b/modules/staking/utils/staking_pool.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"context"
+
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/desmos-labs/juno/client"
+
+	"github.com/forbole/bdjuno/types"
+)
+
+func GetStakingPool(height int64, stakingClient stakingtypes.QueryClient) (*types.Pool, error) {
+	res, err := stakingClient.Pool(
+		context.Background(),
+		&stakingtypes.QueryPoolRequest{},
+		client.GetHeightRequestHeader(height),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return types.NewPool(res.Pool.BondedTokens, res.Pool.NotBondedTokens, height), nil
+}

--- a/types/gov.go
+++ b/types/gov.go
@@ -183,3 +183,51 @@ func NewTallyResult(
 		Height:     height,
 	}
 }
+
+// -------------------------------------------------------------------------------------------------------------------
+
+// ProposalStakingPoolSnapshot contains the data about a single staking pool snapshot to be associated with a proposal
+type ProposalStakingPoolSnapshot struct {
+	ProposalID uint64
+	Pool       *Pool
+}
+
+// NewProposalStakingPoolSnapshot returns a new ProposalStakingPoolSnapshot instance
+func NewProposalStakingPoolSnapshot(proposalID uint64, pool *Pool) ProposalStakingPoolSnapshot {
+	return ProposalStakingPoolSnapshot{
+		ProposalID: proposalID,
+		Pool:       pool,
+	}
+}
+
+// -------------------------------------------------------------------------------------------------------------------
+
+// ProposalValidatorStatusSnapshot represents a single snapshot of the status of a validator associated
+// with a single proposal
+type ProposalValidatorStatusSnapshot struct {
+	ProposalID           uint64
+	ValidatorConsAddress string
+	ValidatorVotingPower int64
+	ValidatorStatus      int
+	ValidatorJailed      bool
+	Height               int64
+}
+
+// NewProposalValidatorStatusSnapshot returns a new ProposalValidatorStatusSnapshot instance
+func NewProposalValidatorStatusSnapshot(
+	proposalID uint64,
+	validatorConsAddr string,
+	validatorVotingPower int64,
+	validatorStatus int,
+	validatorJailed bool,
+	height int64,
+) ProposalValidatorStatusSnapshot {
+	return ProposalValidatorStatusSnapshot{
+		ProposalID:           proposalID,
+		ValidatorStatus:      validatorStatus,
+		ValidatorConsAddress: validatorConsAddr,
+		ValidatorVotingPower: validatorVotingPower,
+		ValidatorJailed:      validatorJailed,
+		Height:               height,
+	}
+}

--- a/types/staking_pool.go
+++ b/types/staking_pool.go
@@ -10,8 +10,8 @@ type Pool struct {
 }
 
 // NewPool allows to build a new Pool instance
-func NewPool(bondedTokens, notBondedTokens sdk.Int, height int64) Pool {
-	return Pool{
+func NewPool(bondedTokens, notBondedTokens sdk.Int, height int64) *Pool {
+	return &Pool{
 		BondedTokens:    bondedTokens,
 		NotBondedTokens: notBondedTokens,
 		Height:          height,

--- a/types/staking_validator.go
+++ b/types/staking_validator.go
@@ -151,9 +151,9 @@ type ValidatorStatus struct {
 }
 
 // NewValidatorStatus creates a new ValidatorVotingPower
-func NewValidatorStatus(address, pubKey string, status int, jailed bool, height int64) ValidatorStatus {
+func NewValidatorStatus(valConsAddr, pubKey string, status int, jailed bool, height int64) ValidatorStatus {
 	return ValidatorStatus{
-		ConsensusAddress: address,
+		ConsensusAddress: valConsAddr,
 		ConsensusPubKey:  pubKey,
 		Status:           status,
 		Jailed:           jailed,


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR adds the ability to snapshot staking data such as validator status and voting power when a proposal is open. This will cause the `x/gov` module to be able to correctly display the data about who voted when a proposal closes (fixes #142). 

It also changes how gRPC connections and clients are created, in order to use a single gRPC connection instead of multiple ones as well as less gRPC clients overall (#141) 

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
