### PR TITLE
fix: `MsgCreateValidator` and `MsgUpdateValidator` race condition

### DIFF
--- a/database/staking_delegations_test.go
+++ b/database/staking_delegations_test.go
@@ -337,7 +337,7 @@ func (suite *DbTestSuite) TestDeleteCompletedRedelegations() {
 			srcValidator1.GetOperator(),
 			dstValidator1.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(100)),
-			time.Date(2021, 1, 1, 12, 00, 01, 000, time.UTC),
+			time.Date(2021, 1, 1, 12, 00, 00, 000, time.UTC),
 			10,
 		),
 		types.NewRedelegation(
@@ -537,7 +537,7 @@ func (suite *DbTestSuite) TestDeleteCompletedUnbondingDelegations() {
 			delegator1.String(),
 			validator1.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(100)),
-			time.Date(2021, 1, 1, 12, 00, 01, 000, time.UTC),
+			time.Date(2021, 1, 1, 12, 00, 00, 000, time.UTC),
 			10,
 		),
 		types.NewUnbondingDelegation(

--- a/modules/registrar.go
+++ b/modules/registrar.go
@@ -2,9 +2,10 @@ package modules
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/tendermint/tendermint/libs/log"
-	"os"
 
 	"github.com/desmos-labs/juno/v2/modules/pruning"
 	"github.com/desmos-labs/juno/v2/modules/telemetry"

--- a/modules/staking/handle_genesis.go
+++ b/modules/staking/handle_genesis.go
@@ -100,7 +100,7 @@ func (m *Module) parseGenesisTransactions(doc *tmtypes.GenesisDoc, appState map[
 				continue
 			}
 
-			err = m.storeValidatorFromMsgCreateValidator(doc.InitialHeight, createValMsg)
+			err = m.handleMsgCreateValidator(doc.InitialHeight, createValMsg)
 			if err != nil {
 				return fmt.Errorf("error while storing validators from MsgCreateValidator: %s", err)
 			}

--- a/modules/staking/source/source.go
+++ b/modules/staking/source/source.go
@@ -3,9 +3,11 @@ package source
 import stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 type Source interface {
+	GetValidator(height int64, valOper string) (stakingtypes.Validator, error)
+	GetValidatorsWithStatus(height int64, status string) ([]stakingtypes.Validator, error)
 	GetDelegation(height int64, delegator string, validator string) (stakingtypes.DelegationResponse, error)
 	GetDelegatorDelegations(height int64, delegator string) ([]stakingtypes.DelegationResponse, error)
-	GetValidatorsWithStatus(height int64, status string) ([]stakingtypes.Validator, error)
+	GetValidatorDelegations(height int64, validator string) ([]stakingtypes.DelegationResponse, error)
 	GetPool(height int64) (stakingtypes.Pool, error)
 	GetParams(height int64) (stakingtypes.Params, error)
 }

--- a/modules/staking/utils_delegations.go
+++ b/modules/staking/utils_delegations.go
@@ -24,7 +24,26 @@ func convertDelegationResponse(height int64, response stakingtypes.DelegationRes
 	)
 }
 
+// convertDelegationResponses converts the given responses to BDJuno Delegation instances
+func convertDelegationResponses(height int64, responses []stakingtypes.DelegationResponse) []types.Delegation {
+	var delegations = make([]types.Delegation, len(responses))
+	for index, delegation := range responses {
+		delegations[index] = convertDelegationResponse(height, delegation)
+	}
+	return delegations
+}
+
 // --------------------------------------------------------------------------------------------------------------------
+
+// getValidatorDelegations returns all the delegations associated to the given validator at a given height
+func (m *Module) getValidatorDelegations(height int64, validator string) ([]types.Delegation, error) {
+	delegations, err := m.source.GetValidatorDelegations(height, validator)
+	if err != nil {
+		return nil, fmt.Errorf("error while getting validator delegations: %s", err)
+	}
+
+	return convertDelegationResponses(height, delegations), nil
+}
 
 // getDelegatorDelegations returns the current delegations for the given delegator
 func (m *Module) getDelegatorDelegations(height int64, delegator string) ([]types.Delegation, error) {
@@ -34,12 +53,7 @@ func (m *Module) getDelegatorDelegations(height int64, delegator string) ([]type
 		return nil, fmt.Errorf("error while getting delegator delegations: %s", err)
 	}
 
-	var delegations = make([]types.Delegation, len(responses))
-	for index, delegation := range responses {
-		delegations[index] = convertDelegationResponse(height, delegation)
-	}
-
-	return delegations, nil
+	return convertDelegationResponses(height, responses), nil
 }
 
 // --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes the `MsgCreateValidator` and `MsgUpdateValidator` race condition bug by changing how we handle those types of messages. Instead of storing the infos directly from them, we use gRPC to query the entire data for the height that those msgs were transmitted to, and then store such information. This way even when a `MsgUpdateValidator` is sent, the entire data will be fetched and stored avoiding partial data storage that caused the bug. 

Fix #219 

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [x] Re-reviewed `Files changed` in the Github PR explorer.
