### PR TITLE
fix: slashing events not being handled properly

### DIFF
--- a/database/staking_delegations.go
+++ b/database/staking_delegations.go
@@ -109,6 +109,21 @@ func (db *Db) GetUserDelegationsAmount(address string) (sdk.Coins, error) {
 	return amount, nil
 }
 
+// DeleteValidatorDelegations removes all the delegations associated with the given validator consensus address
+func (db *Db) DeleteValidatorDelegations(valOperAddr string) error {
+	stmt := `
+DELETE FROM delegation USING validator_info 
+WHERE delegation.validator_address = validator_info.consensus_address 
+  AND validator_info.operator_address = $1`
+
+	_, err := db.Sql.Exec(stmt, valOperAddr)
+	if err != nil {
+		return fmt.Errorf("error while deleting delegations for valdiator: %s", err)
+	}
+
+	return nil
+}
+
 // DeleteDelegatorDelegations removes all the delegations associated with the given delegator
 func (db *Db) DeleteDelegatorDelegations(delegator string) error {
 	stmt := `DELETE FROM delegation WHERE delegator_address = $1`

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/cosmos/cosmos-sdk v0.42.9
-	github.com/desmos-labs/juno/v2 v2.0.0-20211005132114-ecffd42d060e
+	github.com/desmos-labs/juno/v2 v2.0.0-20211008110344-90ae63739f7c
 	github.com/go-co-op/gocron v0.3.3
 	github.com/gogo/protobuf v1.3.3
 	github.com/jmoiron/sqlx v1.2.1-0.20200324155115-ee514944af4b

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0tEMk218=
-github.com/desmos-labs/juno/v2 v2.0.0-20211005132114-ecffd42d060e h1:W6V/TyVTQVuRXd7hef01lxeXFz6hZiDeHjaSUMtSrVI=
-github.com/desmos-labs/juno/v2 v2.0.0-20211005132114-ecffd42d060e/go.mod h1:Dl3qB4QnbZpjcmqv0raaJ0Tu5wJhsIiRoNtWUDp2NI4=
+github.com/desmos-labs/juno/v2 v2.0.0-20211008110344-90ae63739f7c h1:rkFd/tGwnku0nksa6X4WqvdUS55nPFuEIzWFdO15Ux8=
+github.com/desmos-labs/juno/v2 v2.0.0-20211008110344-90ae63739f7c/go.mod h1:Dl3qB4QnbZpjcmqv0raaJ0Tu5wJhsIiRoNtWUDp2NI4=
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/badger/v2 v2.2007.4 h1:TRWBQg8UrlUhaFdco01nO2uXwzKS7zd+HVdwV/GHc4o=
 github.com/dgraph-io/badger/v2 v2.2007.4/go.mod h1:vSw/ax2qojzbN6eXHIx6KPKtCSHJN/Uz0X0VPruTIhk=

--- a/modules/bank/handle_block.go
+++ b/modules/bank/handle_block.go
@@ -9,7 +9,9 @@ import (
 )
 
 // HandleBlock implements modules.BlockModule
-func (m *Module) HandleBlock(block *tmctypes.ResultBlock, _ []*types.Tx, _ *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	block *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*types.Tx, _ *tmctypes.ResultValidators,
+) error {
 	err := m.updateSupply(block.Block.Height)
 	if err != nil {
 		log.Error().Str("module", "bank").Int64("height", block.Block.Height).

--- a/modules/consensus/handle_block.go
+++ b/modules/consensus/handle_block.go
@@ -11,7 +11,9 @@ import (
 )
 
 // HandleBlock implements modules.Module
-func (m *Module) HandleBlock(b *tmctypes.ResultBlock, _ []*types.Tx, _ *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	b *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*types.Tx, _ *tmctypes.ResultValidators,
+) error {
 	err := m.updateBlockTimeFromGenesis(b)
 	if err != nil {
 		log.Error().Str("module", "consensus").Int64("height", b.Block.Height).

--- a/modules/distribution/handle_block.go
+++ b/modules/distribution/handle_block.go
@@ -10,7 +10,9 @@ import (
 )
 
 // HandleBlock implements modules.BlockModule
-func (m *Module) HandleBlock(b *tmctypes.ResultBlock, _ []*juno.Tx, _ *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	b *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*juno.Tx, _ *tmctypes.ResultValidators,
+) error {
 	// Update the params
 	go m.updateParams(b.Block.Height)
 

--- a/modules/gov/handle_block.go
+++ b/modules/gov/handle_block.go
@@ -13,7 +13,9 @@ import (
 )
 
 // HandleBlock implements modules.BlockModule
-func (m *Module) HandleBlock(b *tmctypes.ResultBlock, _ []*juno.Tx, vals *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	b *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*juno.Tx, vals *tmctypes.ResultValidators,
+) error {
 	err := m.updateProposals(b.Block.Height, vals)
 	if err != nil {
 		log.Error().Str("module", "gov").Int64("height", b.Block.Height).

--- a/modules/mint/handle_block.go
+++ b/modules/mint/handle_block.go
@@ -10,7 +10,9 @@ import (
 )
 
 // HandleBlock implements modules.BlockModule
-func (m *Module) HandleBlock(block *tmctypes.ResultBlock, _ []*juno.Tx, _ *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	block *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*juno.Tx, _ *tmctypes.ResultValidators,
+) error {
 	// Update the params
 	go m.updateParams(block.Block.Height)
 

--- a/modules/registrar.go
+++ b/modules/registrar.go
@@ -2,9 +2,10 @@ package modules
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/cosmos/cosmos-sdk/simapp"
 	"github.com/tendermint/tendermint/libs/log"
-	"os"
 
 	"github.com/desmos-labs/juno/v2/modules/pruning"
 	"github.com/desmos-labs/juno/v2/modules/telemetry"
@@ -124,7 +125,7 @@ func (r *Registrar) BuildModules(ctx registrar.Context) jmodules.Modules {
 		mint.NewModule(sources.MintSource, db),
 		modules.NewModule(ctx.JunoConfig.Chain, db),
 		pricefeed.NewModule(ctx.JunoConfig, historyModule, cdc, db),
-		slashing.NewModule(sources.SlashingSource, db),
+		slashing.NewModule(sources.SlashingSource, stakingModule, db),
 		stakingModule,
 	}
 }

--- a/modules/slashing/expected_modules.go
+++ b/modules/slashing/expected_modules.go
@@ -1,0 +1,5 @@
+package slashing
+
+type StakingModule interface {
+	RefreshValidatorDelegations(height int64, valOperAddr string) error
+}

--- a/modules/slashing/handle_block.go
+++ b/modules/slashing/handle_block.go
@@ -1,27 +1,38 @@
 package slashing
 
 import (
+	"fmt"
+
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	juno "github.com/desmos-labs/juno/v2/types"
 
 	"github.com/forbole/bdjuno/v2/types"
 
 	"github.com/rs/zerolog/log"
+	abci "github.com/tendermint/tendermint/abci/types"
 	tmctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
 // HandleBlock implements BlockModule
-func (m *Module) HandleBlock(block *tmctypes.ResultBlock, _ []*juno.Tx, _ *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	block *tmctypes.ResultBlock, results *tmctypes.ResultBlockResults, _ []*juno.Tx, _ *tmctypes.ResultValidators,
+) error {
 	// Update the signing infos
 	err := m.updateSigningInfo(block.Block.Height)
 	if err != nil {
-		log.Error().Str("module", "slashing").Int64("height", block.Block.Height).
-			Err(err).Msg("error while updating signing info")
+		return fmt.Errorf("error while updating signing info: %s", err)
 	}
 
+	// Update the delegations of the slashed validators
+	err = m.updateSlashedDelegations(block.Block.Height, results.BeginBlockEvents)
+	if err != nil {
+		return fmt.Errorf("error while updating slashes: %s", err)
+	}
+
+	// Update the params
 	err = m.updateSlashingParams(block.Block.Height)
 	if err != nil {
-		log.Error().Str("module", "slashing").Int64("height", block.Block.Height).
-			Err(err).Msg("error while updating params")
+		return fmt.Errorf("error while updating slashing params: %s", err)
 	}
 
 	return nil
@@ -29,8 +40,7 @@ func (m *Module) HandleBlock(block *tmctypes.ResultBlock, _ []*juno.Tx, _ *tmcty
 
 // updateSigningInfo reads from the LCD the current staking pool and stores its value inside the database
 func (m *Module) updateSigningInfo(height int64) error {
-	log.Debug().Str("module", "slashing").Int64("height", height).
-		Msg("updating signing info")
+	log.Debug().Str("module", "slashing").Int64("height", height).Msg("updating signing info")
 
 	signingInfos, err := m.getSigningInfos(height)
 	if err != nil {
@@ -40,10 +50,34 @@ func (m *Module) updateSigningInfo(height int64) error {
 	return m.db.SaveValidatorsSigningInfos(signingInfos)
 }
 
+// updateSlashedDelegations updates all the delegations of the slashed validators
+func (m *Module) updateSlashedDelegations(height int64, beginBlockEvents []abci.Event) error {
+	events := juno.FindEventsByType(beginBlockEvents, slashingtypes.EventTypeSlash)
+
+	for _, event := range events {
+		addressAttr, err := juno.FindAttributeByKey(event, slashingtypes.AttributeKeyAddress)
+		if err != nil {
+			return err
+		}
+
+		consAddr := string(addressAttr.Value)
+		valOperAddr, err := m.db.GetValidatorOperatorAddress(consAddr)
+		if err != nil {
+			return fmt.Errorf("error while getting validator operator address; make sure the slashing module is listed after the staking module: %s", err)
+		}
+
+		err = m.stakingModule.RefreshValidatorDelegations(height, valOperAddr.String())
+		if err != nil {
+			return fmt.Errorf("error while refreshing validator delegations for validator %s: %s", consAddr, err)
+		}
+	}
+
+	return nil
+}
+
 // updateSlashingParams gets the slashing params for the given height, and stores them inside the database
 func (m *Module) updateSlashingParams(height int64) error {
-	log.Debug().Str("module", "slashing").Int64("height", height).
-		Msg("updating slashing params")
+	log.Debug().Str("module", "slashing").Int64("height", height).Msg("updating slashing params")
 
 	params, err := m.source.GetParams(height)
 	if err != nil {

--- a/modules/slashing/module.go
+++ b/modules/slashing/module.go
@@ -1,11 +1,10 @@
 package slashing
 
 import (
-	slashingsource "github.com/forbole/bdjuno/v2/modules/slashing/source"
+	"github.com/desmos-labs/juno/v2/modules"
 
 	"github.com/forbole/bdjuno/v2/database"
-
-	"github.com/desmos-labs/juno/v2/modules"
+	slashingsource "github.com/forbole/bdjuno/v2/modules/slashing/source"
 )
 
 var (
@@ -17,13 +16,16 @@ var (
 type Module struct {
 	db     *database.Db
 	source slashingsource.Source
+
+	stakingModule StakingModule
 }
 
 // NewModule returns a new Module instance
-func NewModule(source slashingsource.Source, db *database.Db) *Module {
+func NewModule(source slashingsource.Source, stakingModule StakingModule, db *database.Db) *Module {
 	return &Module{
-		db:     db,
-		source: source,
+		db:            db,
+		source:        source,
+		stakingModule: stakingModule,
 	}
 }
 

--- a/modules/staking/handle_block.go
+++ b/modules/staking/handle_block.go
@@ -16,7 +16,9 @@ import (
 )
 
 // HandleBlock implements BlockModule
-func (m *Module) HandleBlock(block *tmctypes.ResultBlock, _ []*juno.Tx, vals *tmctypes.ResultValidators) error {
+func (m *Module) HandleBlock(
+	block *tmctypes.ResultBlock, _ *tmctypes.ResultBlockResults, _ []*juno.Tx, vals *tmctypes.ResultValidators,
+) error {
 	// Update the validators
 	validators, err := m.updateValidators(block.Block.Height)
 	if err != nil {
@@ -201,7 +203,7 @@ func (m *Module) updateElapsedDelegations(height int64, blockTime time.Time) {
 
 	// Update the delegations and balances of all the delegators
 	for delegator := range delegators {
-		err = m.refreshDelegations(height, delegator)
+		err = m.refreshDelegatorDelegations(height, delegator)
 		if err != nil {
 			log.Error().Str("module", "staking").Err(err).Int64("height", height).
 				Str("delegator", delegator).Msg("error while refreshing the delegations")

--- a/modules/staking/handle_msg.go
+++ b/modules/staking/handle_msg.go
@@ -99,7 +99,7 @@ func (m *Module) handleMsgBeginRedelegate(tx *juno.Tx, index int, msg *stakingty
 	}
 
 	// Update the current delegations
-	return m.refreshDelegations(tx.Height, msg.DelegatorAddress)
+	return m.refreshDelegatorDelegations(tx.Height, msg.DelegatorAddress)
 }
 
 // handleMsgUndelegate handles a MsgUndelegate storing the data inside the database
@@ -110,5 +110,5 @@ func (m *Module) handleMsgUndelegate(tx *juno.Tx, index int, msg *stakingtypes.M
 	}
 
 	// Update the current delegations
-	return m.refreshDelegations(tx.Height, msg.DelegatorAddress)
+	return m.refreshDelegatorDelegations(tx.Height, msg.DelegatorAddress)
 }

--- a/modules/staking/source/source.go
+++ b/modules/staking/source/source.go
@@ -1,9 +1,12 @@
 package source
 
-import stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+import (
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
 
 type Source interface {
-	GetDelegation(height int64, delegator string, validator string) (stakingtypes.DelegationResponse, error)
+	GetDelegation(height int64, delegator string, valOperAddr string) (stakingtypes.DelegationResponse, error)
+	GetValidatorDelegations(height int64, valOperAddr string) ([]stakingtypes.DelegationResponse, error)
 	GetDelegatorDelegations(height int64, delegator string) ([]stakingtypes.DelegationResponse, error)
 	GetValidatorsWithStatus(height int64, status string) ([]stakingtypes.Validator, error)
 	GetPool(height int64) (stakingtypes.Pool, error)

--- a/modules/staking/utils_delegations.go
+++ b/modules/staking/utils_delegations.go
@@ -24,8 +24,8 @@ func convertDelegationResponse(height int64, response stakingtypes.DelegationRes
 	)
 }
 
-// convertDelegationResponses converts the given responses to BDJuno Delegation instances
-func convertDelegationResponses(height int64, responses []stakingtypes.DelegationResponse) []types.Delegation {
+// convertDelegationsResponses converts the given responses to BDJuno Delegation instances
+func convertDelegationsResponses(height int64, responses []stakingtypes.DelegationResponse) []types.Delegation {
 	var delegations = make([]types.Delegation, len(responses))
 	for index, delegation := range responses {
 		delegations[index] = convertDelegationResponse(height, delegation)
@@ -42,7 +42,7 @@ func (m *Module) getValidatorDelegations(height int64, validator string) ([]type
 		return nil, fmt.Errorf("error while getting validator delegations: %s", err)
 	}
 
-	return convertDelegationResponses(height, delegations), nil
+	return convertDelegationsResponses(height, delegations), nil
 }
 
 // getDelegatorDelegations returns the current delegations for the given delegator
@@ -52,7 +52,7 @@ func (m *Module) getDelegatorDelegations(height int64, delegator string) ([]type
 		return nil, fmt.Errorf("error while getting delegator delegations: %s", err)
 	}
 
-	return convertDelegationResponses(height, responses), nil
+	return convertDelegationsResponses(height, responses), nil
 }
 
 // --------------------------------------------------------------------------------------------------------------------

--- a/modules/staking/utils_delegations.go
+++ b/modules/staking/utils_delegations.go
@@ -24,29 +24,52 @@ func convertDelegationResponse(height int64, response stakingtypes.DelegationRes
 	)
 }
 
+// convertDelegationResponse converts the given responses to BDJuno Delegation slice
+func convertDelegationsResponses(height int64, responses []stakingtypes.DelegationResponse) []types.Delegation {
+	var delegations = make([]types.Delegation, len(responses))
+	for index, delegation := range responses {
+		delegations[index] = convertDelegationResponse(height, delegation)
+	}
+	return delegations
+}
+
 // --------------------------------------------------------------------------------------------------------------------
 
 // getDelegatorDelegations returns the current delegations for the given delegator
 func (m *Module) getDelegatorDelegations(height int64, delegator string) ([]types.Delegation, error) {
-	// Get the delegations
 	responses, err := m.source.GetDelegatorDelegations(height, delegator)
 	if err != nil {
 		return nil, fmt.Errorf("error while getting delegator delegations: %s", err)
 	}
 
-	var delegations = make([]types.Delegation, len(responses))
-	for index, delegation := range responses {
-		delegations[index] = convertDelegationResponse(height, delegation)
-	}
-
-	return delegations, nil
+	return convertDelegationsResponses(height, responses), nil
 }
 
 // --------------------------------------------------------------------------------------------------------------------
 
-// refreshDelegations updates the delegations of the given delegator by querying them at the
+// RefreshValidatorDelegations refreshes the delegations for the validator with the given consensus address
+func (m *Module) RefreshValidatorDelegations(height int64, valOperAddr string) error {
+	responses, err := m.source.GetValidatorDelegations(height, valOperAddr)
+	if err != nil {
+		return fmt.Errorf("error while getting validator delegations: %s", err)
+	}
+
+	err = m.db.DeleteValidatorDelegations(valOperAddr)
+	if err != nil {
+		return fmt.Errorf("error while deleting validator delegations: %s", err)
+	}
+
+	err = m.db.SaveDelegations(convertDelegationsResponses(height, responses))
+	if err != nil {
+		return fmt.Errorf("error while storing validator delegations: %s", err)
+	}
+
+	return nil
+}
+
+// refreshDelegatorDelegations updates the delegations of the given delegator by querying them at the
 // required height, and then stores them inside the database by replacing all existing ones.
-func (m *Module) refreshDelegations(height int64, delegator string) error {
+func (m *Module) refreshDelegatorDelegations(height int64, delegator string) error {
 	// Get current delegations
 	delegations, err := m.getDelegatorDelegations(height, delegator)
 	if err != nil {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description
This PR fixes #223 by updating Juno to the latest version. With it, `HandleBlock` now has a new parameter that represents the result of the given block, which contains all the events emitted. From withing the `BeginBlockEvents` we can then read the `slash` events and get the addresses of those validator that are slashed. Once we have them, we simply update all the delegations for that height and validators. 

Tested with the following data:
- Chain: Desmos mainnet
- Parsing start height: `508780` (slashing should happen at block `508799`)

## Checklist
- [x] Targeted PR against correct branch.
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit tests.  
- [ ] Re-reviewed `Files changed` in the Github PR explorer.
