### PR TITLE
fix: fixed vesting periods being stored twice

### DIFF
--- a/cmd/fix/auth/cmd.go
+++ b/cmd/fix/auth/cmd.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"github.com/forbole/juno/v2/cmd/parse"
+	"github.com/spf13/cobra"
+)
+
+// NewAuthCmd returns the Cobra command that allows to fix all the things related to the x/auth module
+func NewAuthCmd(parseCfg *parse.Config) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "auth",
+		Short: "Fix things related to the x/auth module",
+	}
+
+	cmd.AddCommand(
+		vestingCmd(parseCfg),
+	)
+
+	return cmd
+}

--- a/cmd/fix/auth/vesting.go
+++ b/cmd/fix/auth/vesting.go
@@ -16,8 +16,8 @@ import (
 // vestingCmd returns a Cobra command that allows to fix the vesting data for the accounts
 func vestingCmd(parseConfig *parse.Config) *cobra.Command {
 	return &cobra.Command{
-		Use:   "slashes",
-		Short: "Fix the delegations for all the slashed validators, taking their delegations from the latest known height",
+		Use:   "vesting-accounts",
+		Short: "Fix the vesting accounts stored by removing duplicated vesting periods",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			parseCtx, err := parse.GetParsingContext(parseConfig)
 			if err != nil {

--- a/cmd/fix/auth/vesting.go
+++ b/cmd/fix/auth/vesting.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/forbole/juno/v2/cmd/parse"
+	"github.com/forbole/juno/v2/types/config"
+	"github.com/spf13/cobra"
+
+	"github.com/forbole/bdjuno/v2/database"
+	authutils "github.com/forbole/bdjuno/v2/modules/auth"
+	"github.com/forbole/bdjuno/v2/utils"
+)
+
+// vestingCmd returns a Cobra command that allows to fix the vesting data for the accounts
+func vestingCmd(parseConfig *parse.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "slashes",
+		Short: "Fix the delegations for all the slashed validators, taking their delegations from the latest known height",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			parseCtx, err := parse.GetParsingContext(parseConfig)
+			if err != nil {
+				return err
+			}
+
+			// Get the database
+			db := database.Cast(parseCtx.Database)
+
+			// Get the genesis
+			genesis, err := utils.ReadGenesis(config.Cfg, parseCtx.Node)
+			if err != nil {
+				return fmt.Errorf("error while reading the genesis: %s", err)
+			}
+
+			var appState map[string]json.RawMessage
+			if err := json.Unmarshal(genesis.AppState, &appState); err != nil {
+				return fmt.Errorf("error unmarshalling genesis doc: %s", err)
+			}
+
+			vestingAccounts, err := authutils.GetGenesisVestingAccounts(appState, parseCtx.EncodingConfig.Marshaler)
+			if err != nil {
+				return fmt.Errorf("error while gestting vesting accounts: %s", err)
+			}
+
+			err = db.SaveVestingAccounts(vestingAccounts)
+			if err != nil {
+				return fmt.Errorf("error while storing vesting accounts: %s", err)
+			}
+
+			return nil
+		},
+	}
+}

--- a/cmd/fix/fix.go
+++ b/cmd/fix/fix.go
@@ -4,6 +4,7 @@ import (
 	"github.com/forbole/juno/v2/cmd/parse"
 	"github.com/spf13/cobra"
 
+	fixauth "github.com/forbole/bdjuno/v2/cmd/fix/auth"
 	fixgov "github.com/forbole/bdjuno/v2/cmd/fix/gov"
 	fixstaking "github.com/forbole/bdjuno/v2/cmd/fix/staking"
 )
@@ -17,6 +18,7 @@ func NewFixCmd(parseCfg *parse.Config) *cobra.Command {
 	}
 
 	cmd.AddCommand(
+		fixauth.NewAuthCmd(parseCfg),
 		fixgov.NewGovCmd(parseCfg),
 		fixstaking.NewStakingCmd(parseCfg),
 	)

--- a/modules/auth/auth_vesting_accounts.go
+++ b/modules/auth/auth_vesting_accounts.go
@@ -16,7 +16,7 @@ func GetGenesisVestingAccounts(appState map[string]json.RawMessage, cdc codec.Ma
 	}
 
 	// Build vestingAccounts Array
-	vestingAccounts := []exported.VestingAccount{}
+	var vestingAccounts []exported.VestingAccount
 	for _, account := range authState.Accounts {
 		var accountI authttypes.AccountI
 		err := cdc.UnpackAny(account, &accountI)

--- a/utils/genesis.go
+++ b/utils/genesis.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/forbole/juno/v2/node"
+	"github.com/forbole/juno/v2/types/config"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmos "github.com/tendermint/tendermint/libs/os"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+// ReadGenesis reads the genesis data based on the given config
+func ReadGenesis(config config.Config, node node.Node) (*tmtypes.GenesisDoc, error) {
+	if config.Parser.GenesisFilePath != "" {
+		return readGenesisFromFilePath(config.Parser.GenesisFilePath)
+	}
+
+	return readGenesisFromNode(node)
+}
+
+func readGenesisFromFilePath(path string) (*tmtypes.GenesisDoc, error) {
+	bz, err := tmos.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read genesis file: %s", err)
+	}
+
+	var genDoc tmtypes.GenesisDoc
+	err = tmjson.Unmarshal(bz, &genDoc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal genesis doc: %s", err)
+	}
+
+	return &genDoc, nil
+}
+
+func readGenesisFromNode(node node.Node) (*tmtypes.GenesisDoc, error) {
+	response, err := node.Genesis()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get genesis: %s", err)
+	}
+
+	return response.Genesis, nil
+}


### PR DESCRIPTION
## Description
This PR fixed the vesting periods being stored twice. It also introduced a new command to fix already stored periods: 
```
bdjuno fix auth vesting-accounts
```

Closes: #247

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)