### PR TITLE
fix: completed unbonding delegations and redelegations not updating balances

### DIFF
--- a/database/auth.go
+++ b/database/auth.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/x/auth/vesting/exported"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
-	dbtypes "github.com/forbole/bdjuno/v2/database/types"
-	dbutils "github.com/forbole/bdjuno/v2/database/utils"
 	"github.com/gogo/protobuf/proto"
 	"github.com/lib/pq"
+
+	dbtypes "github.com/forbole/bdjuno/v2/database/types"
+	dbutils "github.com/forbole/bdjuno/v2/database/utils"
 
 	"github.com/forbole/bdjuno/v2/types"
 )

--- a/database/schema/03-staking.sql
+++ b/database/schema/03-staking.sql
@@ -163,6 +163,20 @@ CREATE TABLE unbonding_delegation
 CREATE INDEX unbonding_delegation_validator_address_index ON unbonding_delegation (validator_address);
 CREATE INDEX unbonding_delegation_delegator_address_index ON unbonding_delegation (delegator_address);
 
+/* ---- ELAPSED DELEGATIONS --- */
+
+/*
+ * This holds the list of balances that should be refreshed when a redelegation or unbonding delegation
+ * has completed. We store them here cause we need to refresh them one block after the delegation has completed.
+ */
+CREATE TABLE delegators_to_refresh
+(
+    address TEXT   NOT NULL REFERENCES account (address),
+    height  BIGINT NOT NULL,
+    CONSTRAINT unique_address UNIQUE (address)
+);
+
+
 /* ---- DOUBLE SIGN EVIDENCE ---- */
 
 /*

--- a/database/schema/03-staking.sql
+++ b/database/schema/03-staking.sql
@@ -166,7 +166,7 @@ CREATE INDEX unbonding_delegation_delegator_address_index ON unbonding_delegatio
 /* ---- ELAPSED DELEGATIONS --- */
 
 /*
- * This holds the list of balances that should be refreshed when a redelegation or unbonding delegation
+ * This holds the list of addresses whose balances that should be refreshed when a redelegation or unbonding delegation
  * has completed. We store them here cause we need to refresh them one block after the delegation has completed.
  */
 CREATE TABLE delegators_to_refresh

--- a/database/staking_delegations_test.go
+++ b/database/staking_delegations_test.go
@@ -370,10 +370,8 @@ func (suite *DbTestSuite) TestDeleteCompletedRedelegations() {
 
 	// Delete the data
 	timestamp := time.Date(2021, 1, 1, 12, 00, 01, 000, time.UTC)
-	deleted, err := suite.database.DeleteCompletedRedelegations(timestamp)
+	err = suite.database.DeleteCompletedRedelegations(timestamp)
 	suite.Require().NoError(err)
-	suite.Require().Len(deleted, 1)
-	suite.Require().True(reDelegations[0].Equal(deleted[0]))
 
 	var count int
 	err = suite.database.Sql.QueryRow(`SELECT COUNT(*) FRom redelegation`).Scan(&count)
@@ -567,8 +565,6 @@ func (suite *DbTestSuite) TestDeleteCompletedUnbondingDelegations() {
 
 	// Delete the data
 	timestamp := time.Date(2021, 1, 1, 12, 00, 01, 000, time.UTC)
-	deleted, err := suite.database.DeleteCompletedUnbondingDelegations(timestamp)
+	err = suite.database.DeleteCompletedUnbondingDelegations(timestamp)
 	suite.Require().NoError(err)
-	suite.Require().Len(deleted, 1)
-	suite.Require().True(unbondingDelegations[0].Equal(deleted[0]))
 }


### PR DESCRIPTION
## Description
This PR introduces a new way of handling completed unbonding delegations and redelegations. Instead of relying on a single block to handle them, we rely on multiple blocks. For each block we: 
1. look at the events emitted inside the `EndBlocker` to look out for completed unbonding delegations and redelegations
2. if there are any of those, we store the list of the involved delegators into the new `delegators_to_refresh` table
3. we read the list of all the `delegators_to_refresh` for past heights, and we update their balances

In order to make this work, the following table should be added to the database: 
```sql
/*
 * This holds the list of addresses whose balances that should be refreshed when a redelegation or unbonding delegation
 * has completed. We store them here cause we need to refresh them one block after the delegation has completed.
 */
CREATE TABLE delegators_to_refresh
(
    address TEXT   NOT NULL REFERENCES account (address),
    height  BIGINT NOT NULL,
    CONSTRAINT unique_address UNIQUE (address)
);
```

Second attempt to solve #217.
Tested locally with unbonding delegation.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [x] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)