### PR TITLE
perf: improve how delegations and rewards are updated

### DIFF
--- a/cmd/fix/staking/slashes.go
+++ b/cmd/fix/staking/slashes.go
@@ -51,15 +51,9 @@ func slashesCmd(parseConfig *parse.Config) *cobra.Command {
 				}
 
 				// Delete the old delegations
-				err = db.DeleteValidatorDelegations(validator.OperatorAddress)
+				err = db.ReplaceValidatorDelegations(validator.OperatorAddress, staking.ConvertDelegationsResponses(height, delegations))
 				if err != nil {
-					return fmt.Errorf("error while deleting validator delegations: %s", err)
-				}
-
-				// Save the delegations
-				err = db.SaveDelegations(staking.ConvertDelegationsResponses(height, delegations))
-				if err != nil {
-					return fmt.Errorf("error while saving delegations: %s", err)
+					return fmt.Errorf("error while refreshing validator delegations: %s", err)
 				}
 			}
 

--- a/cmd/fix/staking/slashes.go
+++ b/cmd/fix/staking/slashes.go
@@ -51,7 +51,7 @@ func slashesCmd(parseConfig *parse.Config) *cobra.Command {
 				}
 
 				// Delete the old delegations
-				err = db.ReplaceValidatorDelegations(validator.OperatorAddress, staking.ConvertDelegationsResponses(height, delegations))
+				err = db.ReplaceValidatorDelegations(height, validator.OperatorAddress, staking.ConvertDelegationsResponses(delegations))
 				if err != nil {
 					return fmt.Errorf("error while refreshing validator delegations: %s", err)
 				}

--- a/database/auth.go
+++ b/database/auth.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"database/sql"
 	"fmt"
 	"time"
 
@@ -17,43 +18,54 @@ import (
 
 // SaveAccounts saves the given accounts inside the database
 func (db *Db) SaveAccounts(accounts []types.Account) error {
-	paramsNumber := 1
-	slices := dbutils.SplitAccounts(accounts, paramsNumber)
+	tx, err := db.Sql.Begin()
+	if err != nil {
+		return err
+	}
 
-	for _, accounts := range slices {
-		if len(accounts) == 0 {
-			continue
+	err = db.saveAccountsWithTx(tx, accounts)
+	if err != nil {
+		if err = tx.Rollback(); err != nil {
+			return err
 		}
+		return err
+	}
 
-		// Store up-to-date data
-		err := db.saveAccounts(paramsNumber, accounts)
-		if err != nil {
-			return fmt.Errorf("error while storing accounts: %s", err)
-		}
+	err = tx.Commit()
+	if err != nil {
+		return fmt.Errorf("error while committing accounts transaction: %s", err)
 	}
 
 	return nil
 }
 
-func (db *Db) saveAccounts(paramsNumber int, accounts []types.Account) error {
-	if len(accounts) == 0 {
-		return nil
-	}
+// saveAccountsWithTx saves the given accounts using the provided transaction.
+// NOTE: The provided transaction is never committed nor rolled back. The caller must take care of this
+func (db *Db) saveAccountsWithTx(tx *sql.Tx, accounts []types.Account) error {
+	paramsNumber := 1
+	slices := dbutils.SplitAccounts(accounts, paramsNumber)
 
-	stmt := `INSERT INTO account (address) VALUES `
-	var params []interface{}
+	for _, slice := range slices {
+		if len(slice) == 0 {
+			continue
+		}
 
-	for i, account := range accounts {
-		ai := i * paramsNumber
-		stmt += fmt.Sprintf("($%d),", ai+1)
-		params = append(params, account.Address)
-	}
+		// Store the accounts
+		stmt := `INSERT INTO account (address) VALUES `
+		var params []interface{}
 
-	stmt = stmt[:len(stmt)-1]
-	stmt += " ON CONFLICT DO NOTHING"
-	_, err := db.Sql.Exec(stmt, params...)
-	if err != nil {
-		return fmt.Errorf("error while storing accounts: %s", err)
+		for i, account := range slice {
+			ai := i * paramsNumber
+			stmt += fmt.Sprintf("($%d),", ai+1)
+			params = append(params, account.Address)
+		}
+
+		stmt = stmt[:len(stmt)-1]
+		stmt += " ON CONFLICT DO NOTHING"
+		_, err := tx.Exec(stmt, params...)
+		if err != nil {
+			return fmt.Errorf("error while storing accounts: %s", err)
+		}
 	}
 
 	return nil

--- a/database/auth.go
+++ b/database/auth.go
@@ -18,25 +18,9 @@ import (
 
 // SaveAccounts saves the given accounts inside the database
 func (db *Db) SaveAccounts(accounts []types.Account) error {
-	tx, err := db.Sql.Begin()
-	if err != nil {
-		return err
-	}
-
-	err = db.saveAccountsWithTx(tx, accounts)
-	if err != nil {
-		if err = tx.Rollback(); err != nil {
-			return err
-		}
-		return err
-	}
-
-	err = tx.Commit()
-	if err != nil {
-		return fmt.Errorf("error while committing accounts transaction: %s", err)
-	}
-
-	return nil
+	return db.RunTx(func(tx *sql.Tx) error {
+		return db.saveAccountsWithTx(tx, accounts)
+	})
 }
 
 // saveAccountsWithTx saves the given accounts using the provided transaction.

--- a/database/distribution.go
+++ b/database/distribution.go
@@ -129,7 +129,9 @@ func (db *Db) SaveDelegatorsRewardsAmounts(height int64, delegator string, amoun
 	stmt := `DELETE FROM delegation_reward WHERE delegator_address = $1 AND height <= $2`
 	_, err = tx.Exec(stmt, delegator, height)
 	if err != nil {
-		tx.Rollback()
+		if err = tx.Rollback(); err != nil {
+			return err
+		}
 		return fmt.Errorf("error while deleting delegation rewards: %s", err)
 	}
 
@@ -160,7 +162,9 @@ ON CONFLICT ON CONSTRAINT delegation_reward_validator_delegator_unique DO UPDATE
 WHERE delegation_reward.height <= excluded.height`
 	_, err = tx.Exec(stmt, params...)
 	if err != nil {
-		tx.Rollback()
+		if err = tx.Rollback(); err != nil {
+			return err
+		}
 		return fmt.Errorf("error while storing delegation reward: %s", err)
 	}
 

--- a/database/distribution_test.go
+++ b/database/distribution_test.go
@@ -180,8 +180,7 @@ func (suite *DbTestSuite) TestBigDipperDb_SaveDelegatorsRewardsAmounts() {
 	_ = suite.getBlock(12)
 	_ = suite.getBlock(13)
 
-	delegator1 := suite.getAccount("cosmos1z4hfrxvlgl4s8u4n5ngjcw8kdqrcv43599amxs")
-	delegator2 := suite.getAccount("cosmos184ma3twcfjqef6k95ne8w2hk80x2kah7vcwy4a")
+	delegator := suite.getAccount("cosmos1z4hfrxvlgl4s8u4n5ngjcw8kdqrcv43599amxs")
 	validator1 := suite.getValidator(
 		"cosmosvalcons1qqqqrezrl53hujmpdch6d805ac75n220ku09rl",
 		"cosmosvaloper1rcp29q3hpd246n6qak7jluqep4v006cdsc2kkl",
@@ -196,52 +195,34 @@ func (suite *DbTestSuite) TestBigDipperDb_SaveDelegatorsRewardsAmounts() {
 	// Save the data
 	rewards := []types.DelegatorRewardAmount{
 		types.NewDelegatorRewardAmount(
-			delegator1.String(),
 			validator1.GetOperator(),
-			delegator1.String(),
+			delegator.String(),
 			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(100))),
-			10,
 		),
 		types.NewDelegatorRewardAmount(
-			delegator1.String(),
 			validator2.GetOperator(),
-			delegator1.String(),
+			delegator.String(),
 			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(200))),
-			11,
-		),
-		types.NewDelegatorRewardAmount(
-			delegator2.String(),
-			validator2.GetOperator(),
-			delegator2.String(),
-			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(200))),
-			12,
 		),
 	}
-	err := suite.database.SaveDelegatorsRewardsAmounts(rewards)
+	err := suite.database.SaveDelegatorsRewardsAmounts(10, delegator.String(), rewards)
 	suite.Require().NoError(err)
 
 	// Verify the data
 	expected := []bddbtypes.DelegationRewardRow{
 		bddbtypes.NewDelegationRewardRow(
-			delegator1.String(),
+			delegator.String(),
 			validator1.GetConsAddr(),
-			delegator1.String(),
+			delegator.String(),
 			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(100)))),
 			10,
 		),
 		bddbtypes.NewDelegationRewardRow(
-			delegator1.String(),
+			delegator.String(),
 			validator2.GetConsAddr(),
-			delegator1.String(),
+			delegator.String(),
 			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(200)))),
-			11,
-		),
-		bddbtypes.NewDelegationRewardRow(
-			delegator2.String(),
-			validator2.GetConsAddr(),
-			delegator2.String(),
-			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(200)))),
-			12,
+			10,
 		),
 	}
 
@@ -256,55 +237,98 @@ func (suite *DbTestSuite) TestBigDipperDb_SaveDelegatorsRewardsAmounts() {
 
 	// -------------------------------------------------------------------------------------------------------------------
 
-	// Update the data
+	// Update the data (older height)
 	rewards = []types.DelegatorRewardAmount{
 		types.NewDelegatorRewardAmount(
-			delegator1.String(),
 			validator1.GetOperator(),
-			delegator1.String(),
+			delegator.String(),
 			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(120))),
-			10,
-		),
-		types.NewDelegatorRewardAmount(
-			delegator1.String(),
-			validator2.GetOperator(),
-			delegator1.String(),
-			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(180))),
-			9,
-		),
-		types.NewDelegatorRewardAmount(
-			delegator2.String(),
-			validator2.GetOperator(),
-			delegator2.String(),
-			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(50))),
-			13,
 		),
 	}
-	err = suite.database.SaveDelegatorsRewardsAmounts(rewards)
+	err = suite.database.SaveDelegatorsRewardsAmounts(9, delegator.String(), rewards)
 	suite.Require().NoError(err)
 
 	// Verify the data
 	expected = []bddbtypes.DelegationRewardRow{
 		bddbtypes.NewDelegationRewardRow(
-			delegator1.String(),
+			delegator.String(),
 			validator1.GetConsAddr(),
-			delegator1.String(),
-			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(120)))),
+			delegator.String(),
+			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(100)))),
 			10,
 		),
 		bddbtypes.NewDelegationRewardRow(
-			delegator1.String(),
+			delegator.String(),
 			validator2.GetConsAddr(),
-			delegator1.String(),
+			delegator.String(),
 			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(200)))),
-			11,
+			10,
 		),
+	}
+
+	rows = []bddbtypes.DelegationRewardRow{}
+	err = suite.database.Sqlx.Select(&rows, `SELECT * FROM delegation_reward ORDER BY height`)
+	suite.Require().NoError(err)
+	suite.Require().Len(rows, len(expected))
+
+	for index, row := range rows {
+		suite.Require().True(row.Equals(expected[index]))
+	}
+
+	// -------------------------------------------------------------------------------------------------------------------
+
+	// Update the data (same height)
+	rewards = []types.DelegatorRewardAmount{
+		types.NewDelegatorRewardAmount(
+			validator1.GetOperator(),
+			delegator.String(),
+			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(120))),
+		),
+	}
+	err = suite.database.SaveDelegatorsRewardsAmounts(10, delegator.String(), rewards)
+	suite.Require().NoError(err)
+
+	// Verify the data
+	expected = []bddbtypes.DelegationRewardRow{
 		bddbtypes.NewDelegationRewardRow(
-			delegator2.String(),
-			validator2.GetConsAddr(),
-			delegator2.String(),
-			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(50)))),
-			13,
+			delegator.String(),
+			validator1.GetConsAddr(),
+			delegator.String(),
+			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(120)))),
+			10,
+		),
+	}
+
+	rows = []bddbtypes.DelegationRewardRow{}
+	err = suite.database.Sqlx.Select(&rows, `SELECT * FROM delegation_reward ORDER BY height`)
+	suite.Require().NoError(err)
+	suite.Require().Len(rows, len(expected))
+
+	for index, row := range rows {
+		suite.Require().True(row.Equals(expected[index]))
+	}
+
+	// -------------------------------------------------------------------------------------------------------------------
+
+	// Update the data (new height)
+	rewards = []types.DelegatorRewardAmount{
+		types.NewDelegatorRewardAmount(
+			validator1.GetOperator(),
+			delegator.String(),
+			sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(500))),
+		),
+	}
+	err = suite.database.SaveDelegatorsRewardsAmounts(11, delegator.String(), rewards)
+	suite.Require().NoError(err)
+
+	// Verify the data
+	expected = []bddbtypes.DelegationRewardRow{
+		bddbtypes.NewDelegationRewardRow(
+			delegator.String(),
+			validator1.GetConsAddr(),
+			delegator.String(),
+			dbtypes.NewDbDecCoins(sdk.NewDecCoins(sdk.NewDecCoin("cosmos", sdk.NewInt(500)))),
+			11,
 		),
 	}
 

--- a/database/staking_delegations.go
+++ b/database/staking_delegations.go
@@ -171,7 +171,7 @@ WHERE delegation.validator_address = validator_info.consensus_address
 	// Commit the transaction
 	err = tx.Commit()
 	if err != nil {
-		return fmt.Errorf("error while committing validator deelgations transactionL %s", err)
+		return fmt.Errorf("error while committing validator delegations transaction: %s", err)
 	}
 
 	return nil

--- a/database/staking_delegations.go
+++ b/database/staking_delegations.go
@@ -336,34 +336,6 @@ func (db *Db) GetUserRedelegationsAmount(address string) (sdk.Coins, error) {
 	return amount, nil
 }
 
-// DeleteRedelegation removes the given redelegation from the database
-func (db *Db) DeleteRedelegation(redelegation types.Redelegation) error {
-	srcVal, err := db.GetValidator(redelegation.SrcValidator)
-	if err != nil {
-		return fmt.Errorf("error while getting validator: %s", err)
-	}
-
-	dstVal, err := db.GetValidator(redelegation.DstValidator)
-	if err != nil {
-		return fmt.Errorf("error while getting validator: %s", err)
-	}
-
-	stmt := `
-DELETE FROM redelegation 
-WHERE delegator_address = $1 
-  AND src_validator_address = $2 
-  AND dst_validator_address = $3 
-  AND completion_time = $4`
-	_, err = db.Sql.Exec(stmt,
-		redelegation.DelegatorAddress, srcVal.GetConsAddr(), dstVal.GetConsAddr(), redelegation.CompletionTime,
-	)
-	if err != nil {
-		return fmt.Errorf("error while deleting redelegations: %s", err)
-	}
-
-	return nil
-}
-
 // DeleteCompletedRedelegations deletes all the redelegations
 // that have completed before the given timestamp
 func (db *Db) DeleteCompletedRedelegations(timestamp time.Time) error {
@@ -473,29 +445,6 @@ func (db *Db) GetUserUnBondingDelegationsAmount(address string) (sdk.Coins, erro
 	}
 
 	return amount, nil
-}
-
-// DeleteUnbondingDelegation removes the given unbonding delegation from the database
-func (db *Db) DeleteUnbondingDelegation(delegation types.UnbondingDelegation) error {
-	val, err := db.GetValidator(delegation.ValidatorOperAddr)
-	if err != nil {
-		return fmt.Errorf("error while getting validator: %s", err)
-	}
-
-	stmt := `
-DELETE FROM unbonding_delegation 
-WHERE delegator_address = $1 
-  AND validator_address = $2 
-  AND completion_timestamp = $3`
-
-	_, err = db.Sql.Exec(stmt,
-		delegation.DelegatorAddress, val.GetConsAddr(), delegation.CompletionTimestamp,
-	)
-	if err != nil {
-		return fmt.Errorf("error while deleting unbonding delegation: %s", err)
-	}
-
-	return nil
 }
 
 // DeleteCompletedUnbondingDelegations deletes all the unbonding delegations

--- a/database/staking_delegations.go
+++ b/database/staking_delegations.go
@@ -158,7 +158,7 @@ WHERE delegation.validator_address = validator_info.consensus_address
 	_, err = tx.Exec(stmt, valOperAddr, height)
 	if err != nil {
 		tx.Rollback()
-		return fmt.Errorf("error while deleting delegations for valdiator: %s", err)
+		return fmt.Errorf("error while deleting delegations for validator: %s", err)
 	}
 
 	// Store the delegations

--- a/database/staking_delegations_test.go
+++ b/database/staking_delegations_test.go
@@ -42,22 +42,19 @@ func (suite *DbTestSuite) TestDelegations() {
 			delegator1.String(),
 			validator1.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(100)),
-			100,
 		),
 		types.NewDelegation(
 			delegator1.String(),
 			validator2.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(100)),
-			50,
 		),
 		types.NewDelegation(
 			delegator2.String(),
 			validator2.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(200)),
-			101,
 		),
 	}
-	err := suite.database.SaveDelegations(delegations)
+	err := suite.database.SaveDelegations(50, delegations)
 	suite.Require().NoError(err, "inserting delegations should return no error")
 
 	// ------------------------------
@@ -74,7 +71,7 @@ func (suite *DbTestSuite) TestDelegations() {
 			delegator1.String(),
 			validator1.GetConsAddr(),
 			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(100))),
-			100,
+			50,
 		),
 		bddbtypes.NewDelegationRow(
 			delegator1.String(),
@@ -86,7 +83,7 @@ func (suite *DbTestSuite) TestDelegations() {
 			delegator2.String(),
 			validator2.GetConsAddr(),
 			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(200))),
-			101,
+			50,
 		),
 	}
 
@@ -95,31 +92,28 @@ func (suite *DbTestSuite) TestDelegations() {
 		suite.Require().True(delegation.Equal(delRows[index]))
 	}
 
-	// ------------------------------
-	// --- Update the data
-	// ------------------------------
+	// ----------------------------------
+	// --- Update the data (lower height)
+	// ----------------------------------
 
 	delegations = []types.Delegation{
 		types.NewDelegation(
 			delegator1.String(),
 			validator1.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(150)),
-			80,
 		),
 		types.NewDelegation(
 			delegator1.String(),
 			validator2.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(120)),
-			50,
 		),
 		types.NewDelegation(
 			delegator2.String(),
 			validator2.GetOperator(),
 			sdk.NewCoin("cosmos", sdk.NewInt(180)),
-			102,
 		),
 	}
-	err = suite.database.SaveDelegations(delegations)
+	err = suite.database.SaveDelegations(40, delegations)
 	suite.Require().NoError(err, "updating delegations should return no error")
 
 	// ------------------------------
@@ -135,19 +129,135 @@ func (suite *DbTestSuite) TestDelegations() {
 			delegator1.String(),
 			validator1.GetConsAddr(),
 			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(100))),
-			100,
+			50,
 		),
 		bddbtypes.NewDelegationRow(
 			delegator1.String(),
 			validator2.GetConsAddr(),
-			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(120))),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(100))),
 			50,
 		),
 		bddbtypes.NewDelegationRow(
 			delegator2.String(),
 			validator2.GetConsAddr(),
-			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(180))),
-			102,
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(200))),
+			50,
+		),
+	}
+
+	suite.Require().Len(delRows, len(expectedDelRows))
+	for index, delegation := range expectedDelRows {
+		suite.Require().True(delegation.Equal(delRows[index]))
+	}
+
+	// ----------------------------------
+	// --- Update the data (same height)
+	// ----------------------------------
+
+	delegations = []types.Delegation{
+		types.NewDelegation(
+			delegator1.String(),
+			validator1.GetOperator(),
+			sdk.NewCoin("cosmos", sdk.NewInt(150)),
+		),
+		types.NewDelegation(
+			delegator1.String(),
+			validator2.GetOperator(),
+			sdk.NewCoin("cosmos", sdk.NewInt(120)),
+		),
+		types.NewDelegation(
+			delegator2.String(),
+			validator2.GetOperator(),
+			sdk.NewCoin("cosmos", sdk.NewInt(180)),
+		),
+	}
+	err = suite.database.SaveDelegations(40, delegations)
+	suite.Require().NoError(err, "updating delegations should return no error")
+
+	// ------------------------------
+	// --- Verify the data
+	// ------------------------------
+
+	delRows = []bddbtypes.DelegationRow{}
+	err = suite.database.Sqlx.Select(&delRows, `SELECT * FROM delegation`)
+	suite.Require().NoError(err)
+
+	expectedDelRows = []bddbtypes.DelegationRow{
+		bddbtypes.NewDelegationRow(
+			delegator1.String(),
+			validator1.GetConsAddr(),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(100))),
+			50,
+		),
+		bddbtypes.NewDelegationRow(
+			delegator1.String(),
+			validator2.GetConsAddr(),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(100))),
+			50,
+		),
+		bddbtypes.NewDelegationRow(
+			delegator2.String(),
+			validator2.GetConsAddr(),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(200))),
+			50,
+		),
+	}
+
+	suite.Require().Len(delRows, len(expectedDelRows))
+	for index, delegation := range expectedDelRows {
+		suite.Require().True(delegation.Equal(delRows[index]))
+	}
+
+	// ----------------------------------
+	// --- Update the data (higher height)
+	// ----------------------------------
+
+	delegations = []types.Delegation{
+		types.NewDelegation(
+			delegator1.String(),
+			validator1.GetOperator(),
+			sdk.NewCoin("cosmos", sdk.NewInt(15)),
+		),
+		types.NewDelegation(
+			delegator1.String(),
+			validator2.GetOperator(),
+			sdk.NewCoin("cosmos", sdk.NewInt(12)),
+		),
+		types.NewDelegation(
+			delegator2.String(),
+			validator2.GetOperator(),
+			sdk.NewCoin("cosmos", sdk.NewInt(18)),
+		),
+	}
+	err = suite.database.SaveDelegations(100, delegations)
+	suite.Require().NoError(err, "updating delegations should return no error")
+
+	// ------------------------------
+	// --- Verify the data
+	// ------------------------------
+
+	delRows = []bddbtypes.DelegationRow{}
+	err = suite.database.Sqlx.Select(&delRows, `SELECT * FROM delegation`)
+	suite.Require().NoError(err)
+
+	expectedDelRows = []bddbtypes.DelegationRow{
+		bddbtypes.NewDelegationRow(
+			delegator1.String(),
+			validator1.GetConsAddr(),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(15))),
+			100,
+		),
+		bddbtypes.NewDelegationRow(
+			delegator1.String(),
+			validator2.GetConsAddr(),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(12))),
+			100,
+		),
+		bddbtypes.NewDelegationRow(
+			delegator2.String(),
+			validator2.GetConsAddr(),
+			dbtypes.NewDbCoin(sdk.NewCoin("cosmos", sdk.NewInt(18))),
+			100,
 		),
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/cosmos/cosmos-sdk v0.42.9
-	github.com/forbole/juno/v2 v2.0.0-20211213105313-d167239d2dad
+	github.com/forbole/juno/v2 v2.0.0-20211220083227-410ca32674d7
 	github.com/go-co-op/gocron v1.11.0
 	github.com/gogo/protobuf v1.3.3
 	github.com/jmoiron/sqlx v1.2.1-0.20200324155115-ee514944af4b

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/forbole/juno/v2 v2.0.0-20211213105313-d167239d2dad h1:0rhtVBf124+gEd7lZtohkR5FshoJgnldaVswpeHftDI=
-github.com/forbole/juno/v2 v2.0.0-20211213105313-d167239d2dad/go.mod h1:nOZEHr5+sZDXEDpV2E+NHkmH0Zvf4prkt5+UVKwScQ8=
+github.com/forbole/juno/v2 v2.0.0-20211220083227-410ca32674d7 h1:nxnQqb5NSQLPEVaOS7zYaSa34i1HuFSzgpqfnjc1lc4=
+github.com/forbole/juno/v2 v2.0.0-20211220083227-410ca32674d7/go.mod h1:nOZEHr5+sZDXEDpV2E+NHkmH0Zvf4prkt5+UVKwScQ8=
 github.com/forbole/tendermint v0.34.13-0.20210820072129-a2a4af55563d h1:pUqGUgTUU24ibHeloQeg1F2pFbgQllddsuZ+x+CcUzw=
 github.com/forbole/tendermint v0.34.13-0.20210820072129-a2a4af55563d/go.mod h1:aeHL7alPh4uTBIJQ8mgFEE8VwJLXI1VD3rVOmH2Mcy0=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/modules/distribution/utils_delegator_rewards.go
+++ b/modules/distribution/utils_delegator_rewards.go
@@ -65,12 +65,7 @@ func (m *Module) RefreshDelegatorRewards(height int64, delegator string) error {
 		return fmt.Errorf("error while refreshing delegator rewards: %s", err)
 	}
 
-	err = m.db.DeleteDelegatorRewardsAmount(delegator, height)
-	if err != nil {
-		return fmt.Errorf("error deleting the delegator rewards amount: %s", err)
-	}
-
-	err = m.db.SaveDelegatorsRewardsAmounts(rewards)
+	err = m.db.SaveDelegatorsRewardsAmounts(height, delegator, rewards)
 	if err != nil {
 		return fmt.Errorf("error while saving delegators rewards amounts: %s", err)
 	}
@@ -92,13 +87,7 @@ func (m *Module) getDelegatorRewardsAmounts(height int64, delegator string) ([]t
 
 	var rewards = make([]types.DelegatorRewardAmount, len(rews))
 	for index, reward := range rews {
-		rewards[index] = types.NewDelegatorRewardAmount(
-			delegator,
-			reward.ValidatorAddress,
-			withdrawAddr,
-			reward.Reward,
-			height,
-		)
+		rewards[index] = types.NewDelegatorRewardAmount(reward.ValidatorAddress, withdrawAddr, reward.Reward)
 	}
 
 	return rewards, nil

--- a/modules/distribution/utils_delegator_rewards.go
+++ b/modules/distribution/utils_delegator_rewards.go
@@ -75,7 +75,7 @@ func (m *Module) RefreshDelegatorRewards(height int64, delegator string) error {
 
 // getDelegatorRewardsAmounts returns the rewards for the given delegator at the given height
 func (m *Module) getDelegatorRewardsAmounts(height int64, delegator string) ([]types.DelegatorRewardAmount, error) {
-	rews, err := m.source.DelegatorTotalRewards(delegator, height)
+	rows, err := m.source.DelegatorTotalRewards(delegator, height)
 	if err != nil {
 		return nil, fmt.Errorf("error while getting delegator reward: %s", err)
 	}
@@ -85,8 +85,8 @@ func (m *Module) getDelegatorRewardsAmounts(height int64, delegator string) ([]t
 		return nil, fmt.Errorf("error while getting delegator rewards: %s", err)
 	}
 
-	var rewards = make([]types.DelegatorRewardAmount, len(rews))
-	for index, reward := range rews {
+	var rewards = make([]types.DelegatorRewardAmount, len(rows))
+	for index, reward := range rows {
 		rewards[index] = types.NewDelegatorRewardAmount(reward.ValidatorAddress, withdrawAddr, reward.Reward)
 	}
 

--- a/modules/staking/handle_genesis.go
+++ b/modules/staking/handle_genesis.go
@@ -161,12 +161,11 @@ func (m *Module) saveDelegations(doc *tmtypes.GenesisDoc, genState stakingtypes.
 				delegation.DelegatorAddress,
 				validator.OperatorAddress,
 				sdk.NewCoin(genState.Params.BondDenom, delegationAmount),
-				doc.InitialHeight,
 			))
 		}
 	}
 
-	return m.db.SaveDelegations(delegations)
+	return m.db.SaveDelegations(doc.InitialHeight, delegations)
 }
 
 // findDelegations returns the list of all the delegations that are

--- a/modules/staking/handle_msg.go
+++ b/modules/staking/handle_msg.go
@@ -51,7 +51,7 @@ func (m *Module) handleMsgCreateValidator(height int64, msg *stakingtypes.MsgCre
 		return nil
 	}
 
-	return m.db.SaveDelegations(delegations)
+	return m.db.SaveDelegations(height, delegations)
 }
 
 // handleEditValidator handles MsgEditValidator utils, updating the validator info and commission

--- a/modules/staking/utils_delegations.go
+++ b/modules/staking/utils_delegations.go
@@ -63,14 +63,9 @@ func (m *Module) RefreshValidatorDelegations(height int64, valOperAddr string) e
 		return fmt.Errorf("error while getting validator delegations: %s", err)
 	}
 
-	err = m.db.DeleteValidatorDelegations(valOperAddr)
+	err = m.db.ReplaceValidatorDelegations(valOperAddr, ConvertDelegationsResponses(height, responses))
 	if err != nil {
-		return fmt.Errorf("error while deleting validator delegations: %s", err)
-	}
-
-	err = m.db.SaveDelegations(ConvertDelegationsResponses(height, responses))
-	if err != nil {
-		return fmt.Errorf("error while storing validator delegations: %s", err)
+		return fmt.Errorf("error while refreshing validator delegations: %s", err)
 	}
 
 	return nil

--- a/modules/staking/utils_delegations.go
+++ b/modules/staking/utils_delegations.go
@@ -96,16 +96,10 @@ func (m *Module) refreshDelegatorDelegations(height int64, delegator string) err
 		}
 	}
 
-	// Remove existing delegations
-	err = m.db.DeleteDelegatorDelegations(delegator)
+	// Replace existing delegations
+	err = m.db.ReplaceDelegatorDelegations(delegator, delegations)
 	if err != nil {
-		return fmt.Errorf("error while deleting delegator delegations: %s", err)
-	}
-
-	// Save new delegations
-	err = m.db.SaveDelegations(delegations)
-	if err != nil {
-		return fmt.Errorf("error while saving delegations: %s", err)
+		return fmt.Errorf("error while replacing delegator delegations: %s", err)
 	}
 
 	// Refresh the delegator rewards

--- a/modules/staking/utils_delegations.go
+++ b/modules/staking/utils_delegations.go
@@ -14,20 +14,19 @@ const (
 )
 
 // convertDelegationResponse converts the given response to a BDJuno Delegation instance
-func convertDelegationResponse(height int64, response stakingtypes.DelegationResponse) types.Delegation {
+func convertDelegationResponse(response stakingtypes.DelegationResponse) types.Delegation {
 	return types.NewDelegation(
 		response.Delegation.DelegatorAddress,
 		response.Delegation.ValidatorAddress,
 		response.Balance,
-		height,
 	)
 }
 
 // ConvertDelegationsResponses converts the given responses to BDJuno Delegation instances
-func ConvertDelegationsResponses(height int64, responses []stakingtypes.DelegationResponse) []types.Delegation {
+func ConvertDelegationsResponses(responses []stakingtypes.DelegationResponse) []types.Delegation {
 	var delegations = make([]types.Delegation, len(responses))
 	for index, delegation := range responses {
-		delegations[index] = convertDelegationResponse(height, delegation)
+		delegations[index] = convertDelegationResponse(delegation)
 	}
 	return delegations
 }
@@ -41,7 +40,7 @@ func (m *Module) getValidatorDelegations(height int64, validator string) ([]type
 		return nil, fmt.Errorf("error while getting validator delegations: %s", err)
 	}
 
-	return ConvertDelegationsResponses(height, delegations), nil
+	return ConvertDelegationsResponses(delegations), nil
 }
 
 // getDelegatorDelegations returns the current delegations for the given delegator
@@ -51,7 +50,7 @@ func (m *Module) getDelegatorDelegations(height int64, delegator string) ([]type
 		return nil, fmt.Errorf("error while getting delegator delegations: %s", err)
 	}
 
-	return ConvertDelegationsResponses(height, responses), nil
+	return ConvertDelegationsResponses(responses), nil
 }
 
 // --------------------------------------------------------------------------------------------------------------------
@@ -63,7 +62,7 @@ func (m *Module) RefreshValidatorDelegations(height int64, valOperAddr string) e
 		return fmt.Errorf("error while getting validator delegations: %s", err)
 	}
 
-	err = m.db.ReplaceValidatorDelegations(valOperAddr, ConvertDelegationsResponses(height, responses))
+	err = m.db.ReplaceValidatorDelegations(height, valOperAddr, ConvertDelegationsResponses(responses))
 	if err != nil {
 		return fmt.Errorf("error while refreshing validator delegations: %s", err)
 	}
@@ -92,7 +91,7 @@ func (m *Module) refreshDelegatorDelegations(height int64, delegator string) err
 	}
 
 	// Replace existing delegations
-	err = m.db.ReplaceDelegatorDelegations(delegator, delegations)
+	err = m.db.ReplaceDelegatorDelegations(height, delegator, delegations)
 	if err != nil {
 		return fmt.Errorf("error while replacing delegator delegations: %s", err)
 	}

--- a/modules/staking/utils_gentx.go
+++ b/modules/staking/utils_gentx.go
@@ -53,12 +53,11 @@ func (m *Module) StoreValidatorsFromMsgCreateValidator(height int64, msg *stakin
 	}
 
 	// Save the first self-delegations
-	err = m.db.SaveDelegations([]types.Delegation{
+	err = m.db.SaveDelegations(height, []types.Delegation{
 		types.NewDelegation(
 			msg.DelegatorAddress,
 			msg.ValidatorAddress,
 			msg.Value,
-			height,
 		),
 	})
 	if err != nil {

--- a/modules/staking/utils_messages.go
+++ b/modules/staking/utils_messages.go
@@ -17,8 +17,8 @@ func (m *Module) storeDelegationFromMessage(height int64, msg *stakingtypes.MsgD
 		return err
 	}
 
-	return m.db.SaveDelegations([]types.Delegation{
-		convertDelegationResponse(height, delegation),
+	return m.db.SaveDelegations(height, []types.Delegation{
+		convertDelegationResponse(delegation),
 	})
 }
 

--- a/types/distribution.go
+++ b/types/distribution.go
@@ -46,21 +46,15 @@ func NewValidatorCommissionAmount(
 // DelegatorRewardAmount contains the data of a delegator commission amount
 type DelegatorRewardAmount struct {
 	ValidatorOperAddr string
-	DelegatorAddress  string
 	WithdrawAddress   string
 	Amount            []sdk.DecCoin
-	Height            int64
 }
 
 // NewDelegatorRewardAmount allows to build a new DelegatorRewardAmount instance
-func NewDelegatorRewardAmount(
-	delegator, valOperAddr, withdrawAddress string, amount sdk.DecCoins, height int64,
-) DelegatorRewardAmount {
+func NewDelegatorRewardAmount(valOperAddr, withdrawAddress string, amount sdk.DecCoins) DelegatorRewardAmount {
 	return DelegatorRewardAmount{
 		ValidatorOperAddr: valOperAddr,
-		DelegatorAddress:  delegator,
 		WithdrawAddress:   withdrawAddress,
 		Amount:            amount,
-		Height:            height,
 	}
 }

--- a/types/staking_delegations.go
+++ b/types/staking_delegations.go
@@ -13,17 +13,15 @@ type Delegation struct {
 	DelegatorAddress  string
 	ValidatorOperAddr string
 	Amount            sdk.Coin
-	Height            int64
 }
 
 // NewDelegation creates a new Delegation instance containing
 // the given data
-func NewDelegation(delegator string, validatorOperAddr string, amount sdk.Coin, height int64) Delegation {
+func NewDelegation(delegator string, validatorOperAddr string, amount sdk.Coin) Delegation {
 	return Delegation{
 		DelegatorAddress:  delegator,
 		ValidatorOperAddr: validatorOperAddr,
 		Amount:            amount,
-		Height:            height,
 	}
 }
 


### PR DESCRIPTION
## Description
This PR implements a better way of updating delegation rewards and delegations themselves. Instead of relying on multiple queries (delete + insert), we replaced everything with a single [transaction](https://www.postgresql.org/docs/current/tutorial-transactions.html). This should improve the performance of the updates as well as provide a fix for empty events being sent to Hasura when such updates are performed (ref forbole/forbole-x#503). Using a single transaction should update all the rows at the same time, without any empty event in between. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)