### PR TITLE
fix: filter out empty PriceID returned from GetTokensPriceID()

### DIFF
--- a/database/pricefeed.go
+++ b/database/pricefeed.go
@@ -22,7 +22,9 @@ func (db *Db) GetTokensPriceID() ([]string, error) {
 
 	var units []string
 	for _, unit := range dbUnits {
-		units = append(units, unit.PriceID.String)
+		if unit.PriceID.String != "" {
+			units = append(units, unit.PriceID.String)
+		}
 	}
 
 	return units, nil


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Currently GetTokensPriceID() can return empty price id, for example: ["", "dsm"]
the first empty string will cause coingecko API ("/coins/markets?vs_currency=usd&**ids=,dsm**") to fetch whatever price of unwanted id and thus error out with failing to insert into DB given the foreign key constraint. 

ERR log: _insert or update on table \"token_price\" violates foreign key constraint \"token_price_unit_name_fkey\"_

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)