### PR TITLE
Including validators commissions in regular update

### DIFF
--- a/modules/staking/utils_validators.go
+++ b/modules/staking/utils_validators.go
@@ -153,7 +153,7 @@ func (m *Module) updateValidators(height int64) ([]stakingtypes.Validator, error
 		return nil, fmt.Errorf("error while getting validator: %s", err)
 	}
 
-	err = m.db.SaveValidatorsData(validators)
+	err = m.db.SaveValidatorsData(validators, vals)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
we have recently found a problem that lead to the fact that the Validators commission shown on the explorer was 0, although they actually has such set on chain. The problem was that the SQL DB had an overflow problem ( Decimal > BigInt ). This was fixed but some validators had their messages parsed before the fix and thus was not saved to the DB.

The fix was to reparse the whole database from scratch with a valid schema and the messages were saved correctly.

However, if BDJuno includes validators commission rates in the updates it pulls from the chain on every block, this problem would have been self fixed, thus this code change suggestion addresses this, whether you may find it useful to be included.

It is using an already existing implementations.

Currently BDJuno make calls to the node on every block height to “pull“ latest and ongoing data in order to update the DB. The current periodic calls to the nodes staking module, which is responsible to keep the current state of the validator commissions on the chain, refresh the following information in the database on every block:

ValidatorVotingPower
ValidatorsStatus
DoubleSignEvidence
StakingPool
ElapsedDelegations

Before the above updates, it makes another one, through the updateValidators method, which rewrites all the values in validator_info table in the DB (consensus_address, operator_address, self_delegate_address, max_change_rate, max_rate, height)

What I’ve done is to use the implementation of this method and an already existing iteration over the current validators to call another existing method SaveValidatorCommission, which updates validator_commission table in the DB.

Simply - I include the validators commission rates to be part of the periodic updates on the price of the associated additional DB writes.