### PR TITLE
fix: remove time label from hasura actions prometheus

### DIFF
--- a/modules/actions/logging/prometheus.go
+++ b/modules/actions/logging/prometheus.go
@@ -10,7 +10,7 @@ var ActionResponseTime = prometheus.NewHistogramVec(
 		Name:    "bdjuno_action_response_time",
 		Help:    "Time it has taken to execute an action",
 		Buckets: []float64{0.5, 1, 2, 3, 4, 5},
-	}, []string{"path", "time"})
+	}, []string{"path"})
 
 // ActionCounter represents the Telemetry counter used to track the total number of actions executed
 var ActionCounter = prometheus.NewCounterVec(

--- a/modules/actions/logging/utils.go
+++ b/modules/actions/logging/utils.go
@@ -15,6 +15,6 @@ func ErrorCounter(path string) {
 }
 
 func ReponseTimeBuckets(path string, start time.Time) {
-	ActionResponseTime.WithLabelValues(path, fmt.Sprintf("%v", time.Since(start).Seconds())).
+	ActionResponseTime.WithLabelValues(path).
 		Observe(time.Since(start).Seconds())
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Due to the time label being different, the monitoring for hasura actions histogram will not accumulate even under the same action name.

Current monitoring: 
```
# TYPE bdjuno_action_response_time histogram
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="0.5"} 0
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="1"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="2"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="3"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="4"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="5"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="0.624719333",le="+Inf"} 1
bdjuno_action_response_time_sum{path="/delegation",time="0.624719333"} 0.624738125
bdjuno_action_response_time_count{path="/delegation",time="0.624719333"} 1

bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="0.5"} 0
bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="1"} 0
bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="2"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="3"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="4"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="5"} 1
bdjuno_action_response_time_bucket{path="/delegation",time="1.586871667",le="+Inf"} 1
bdjuno_action_response_time_sum{path="/delegation",time="1.586871667"} 1.586899834
bdjuno_action_response_time_count{path="/delegation",time="1.586871667"} 1

```

Updated monitoring:
```
# TYPE bdjuno_action_response_time histogram
bdjuno_action_response_time_bucket{path="/delegation",le="0.5"} 0
bdjuno_action_response_time_bucket{path="/delegation",le="1"} 2
bdjuno_action_response_time_bucket{path="/delegation",le="2"} 2
bdjuno_action_response_time_bucket{path="/delegation",le="3"} 2
bdjuno_action_response_time_bucket{path="/delegation",le="4"} 2
bdjuno_action_response_time_bucket{path="/delegation",le="5"} 2
bdjuno_action_response_time_bucket{path="/delegation",le="+Inf"} 2
bdjuno_action_response_time_sum{path="/delegation"} 1.5621203750000001
bdjuno_action_response_time_count{path="/delegation"} 2
```

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)