### PR TITLE
fix: save all coins from total supply query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Hasura
 - ([\#395](https://github.com/forbole/bdjuno/pull/395)) Remove time label from Hasura Prometheus monitoring
 
+#### Bank module
+- ([\#410](https://github.com/forbole/bdjuno/pull/410)) Change total supply query from only 1 page to all pages
 
 ## Version v3.0.1
 ### Dependencies

--- a/modules/bank/source/local/source.go
+++ b/modules/bank/source/local/source.go
@@ -3,6 +3,7 @@ package local
 import (
 	"fmt"
 
+	"github.com/cosmos/cosmos-sdk/types/query"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -50,19 +51,35 @@ func (s Source) GetBalances(addresses []string, height int64) ([]types.AccountBa
 	return balances, nil
 }
 
-// GetSupply implements keeper.Source
+// GetSupply implements bankkeeper.Source
 func (s Source) GetSupply(height int64) (sdk.Coins, error) {
 	ctx, err := s.LoadHeight(height)
 	if err != nil {
 		return nil, fmt.Errorf("error while loading height: %s", err)
 	}
 
-	res, err := s.q.TotalSupply(sdk.WrapSDKContext(ctx), &banktypes.QueryTotalSupplyRequest{})
-	if err != nil {
-		return nil, err
+	var coins []sdk.Coin
+	var nextKey []byte
+	var stop = false
+	for !stop {
+		res, err := s.q.TotalSupply(
+			sdk.WrapSDKContext(ctx),
+			&banktypes.QueryTotalSupplyRequest{
+				Pagination: &query.PageRequest{
+					Key:   nextKey,
+					Limit: 100, // Query 100 supplies at time
+				},
+			})
+		if err != nil {
+			return nil, fmt.Errorf("error while getting total supply: %s", err)
+		}
+
+		nextKey = res.Pagination.NextKey
+		stop = len(res.Pagination.NextKey) == 0
+		coins = append(coins, res.Supply...)
 	}
 
-	return res.Supply, nil
+	return coins, nil
 }
 
 // GetAccountBalances implements bankkeeper.Source

--- a/modules/bank/source/remote/source.go
+++ b/modules/bank/source/remote/source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/query"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/forbole/juno/v3/node/remote"
 
@@ -51,10 +52,28 @@ func (s Source) GetBalances(addresses []string, height int64) ([]types.AccountBa
 
 // GetSupply implements bankkeeper.Source
 func (s Source) GetSupply(height int64) (sdk.Coins, error) {
-	res, err := s.bankClient.TotalSupply(remote.GetHeightRequestContext(s.Ctx, height), &banktypes.QueryTotalSupplyRequest{})
-	if err != nil {
-		return nil, fmt.Errorf("error while getting total supply: %s", err)
+	ctx := remote.GetHeightRequestContext(s.Ctx, height)
+
+	var coins []sdk.Coin
+	var nextKey []byte
+	var stop = false
+	for !stop {
+		res, err := s.bankClient.TotalSupply(
+			ctx,
+			&banktypes.QueryTotalSupplyRequest{
+				Pagination: &query.PageRequest{
+					Key:   nextKey,
+					Limit: 100, // Query 100 supplies at time
+				},
+			})
+		if err != nil {
+			return nil, fmt.Errorf("error while getting total supply: %s", err)
+		}
+
+		nextKey = res.Pagination.NextKey
+		stop = len(res.Pagination.NextKey) == 0
+		coins = append(coins, res.Supply...)
 	}
 
-	return res.Supply, nil
+	return coins, nil
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Currently BDjuno only stores 1 page of total supply, which can lead to the native token being not on the 1 page of query and we fail to store it. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)