### PR TITLE
fix: missing go.sum entry when building container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.16-alpine AS builder
 RUN apk update && apk add --no-cache make git
 WORKDIR /go/src/github.com/forbole/bdjuno
 COPY . ./
+RUN go mod download
 RUN make build
 
 FROM alpine:latest


### PR DESCRIPTION
## Description
When building the container image, I got this error
go: github.com/cosmos/cosmos-sdk@v0.45.4 requires github.com/prometheus/client_golang@v1.12.1: missing go.sum entry; to add it: go mod download github.com/prometheus/client_golang make: *** [Makefile:31: build] Error 1

This can be solved by adding go mod download before running make build command