### PR TITLE
fix: [osmosis] calculate inflation based on actual epoch provisions

### DIFF
--- a/modules/mint/handle_periodic_operations.go
+++ b/modules/mint/handle_periodic_operations.go
@@ -41,7 +41,12 @@ func (m *Module) updateInflation() error {
 		return err
 	}
 
-	epochProvisions := new(big.Float).SetInt64(mintParams.GenesisEpochProvisions.RoundInt64())
+	epochProvisions, err := m.source.EpochProvisions(height)
+	if err != nil {
+		return err
+	}
+
+	epochProvisionsFloat := new(big.Float).SetInt64(epochProvisions.RoundInt64())
 	epochPeriod := new(big.Float).SetInt64(mintParams.ReductionPeriodInEpochs)
 
 	totalSupply, err := m.db.GetTotalSupply()
@@ -53,7 +58,7 @@ func (m *Module) updateInflation() error {
 		return err
 	}
 
-	totalProvisions := new(big.Float).Mul(epochProvisions, epochPeriod)
+	totalProvisions := new(big.Float).Mul(epochProvisionsFloat, epochPeriod)
 	inflation := new(big.Float).Quo(totalProvisions, new(big.Float).SetInt64(supply))
 
 	return m.db.SaveInflation(inflation.String(), height)

--- a/modules/mint/source/local/source.go
+++ b/modules/mint/source/local/source.go
@@ -41,3 +41,18 @@ func (s Source) Params(height int64) (minttypes.Params, error) {
 
 	return res.Params, nil
 }
+
+// Params implements mintsource.Source
+func (s Source) EpochProvisions(height int64) (sdk.Dec, error) {
+	ctx, err := s.LoadHeight(height)
+	if err != nil {
+		return sdk.Dec{}, fmt.Errorf("error while loading height: %s", err)
+	}
+
+	res, err := s.querier.EpochProvisions(sdk.WrapSDKContext(ctx), &minttypes.QueryEpochProvisionsRequest{})
+	if err != nil {
+		return sdk.Dec{}, nil
+	}
+
+	return res.EpochProvisions, nil
+}

--- a/modules/mint/source/remote/source.go
+++ b/modules/mint/source/remote/source.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	minttypes "github.com/MonOsmosis/osmosis/v10/x/mint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	mintsource "github.com/forbole/bdjuno/v3/modules/mint/source"
 	"github.com/forbole/juno/v3/node/remote"
 )
@@ -32,4 +33,14 @@ func (s Source) Params(height int64) (minttypes.Params, error) {
 	}
 
 	return res.Params, nil
+}
+
+// Params implements mintsource.Source
+func (s Source) EpochProvisions(height int64) (sdk.Dec, error) {
+	res, err := s.querier.EpochProvisions(remote.GetHeightRequestContext(s.Ctx, height), &minttypes.QueryEpochProvisionsRequest{})
+	if err != nil {
+		return sdk.Dec{}, nil
+	}
+
+	return res.EpochProvisions, nil
 }

--- a/modules/mint/source/source.go
+++ b/modules/mint/source/source.go
@@ -2,8 +2,10 @@ package source
 
 import (
 	minttypes "github.com/MonOsmosis/osmosis/v10/x/mint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type Source interface {
 	Params(height int64) (minttypes.Params, error)
+	EpochProvisions(height int64) (sdk.Dec, error)
 }


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR fixes the osmosis inflation by replacing the `GenesisEpochProvisions` with `actual epoch provision` queried from the chain. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)