### PR TITLE
acquired initial params of different modules

### DIFF
--- a/database/consensus.go
+++ b/database/consensus.go
@@ -14,6 +14,9 @@ func (db *Db) GetLastBlock() (*dbtypes.BlockRow, error) {
 	stmt := `SELECT * FROM block ORDER BY height DESC LIMIT 1`
 
 	var blocks []dbtypes.BlockRow
+
+	time.Sleep(5 * time.Second)
+
 	if err := db.Sqlx.Select(&blocks, stmt); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Have delayed the psql query so that the m.db.GetLastBlock() in periodic operation functions of different modules does not return error because length of block DB is 0.