### PR TITLE
fix: support building bdjuno image for chains with CosmWasm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,35 @@ FROM golang:1.18-alpine AS builder
 RUN apk update && apk add --no-cache make git
 WORKDIR /go/src/github.com/forbole/bdjuno
 COPY . ./
+
+######################################################
+## Enabe the lines below if chain supports cosmwasm ##
+## module to properly build docker image            ##
+######################################################
+#RUN apk update && apk add --no-cache ca-certificates build-base git
+#ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+#ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+#RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 9ecb037336bd56076573dc18c26631a9d2099a7f2b40dc04b6cae31ffb4c8f9a
+#RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 6e4de7ba9bad4ae9679c7f9ecf7e283dd0160e71567c6a7be6ae47c81ebe7f32
+## Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
+#RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
+
 RUN go mod download
 RUN make build
 
+##################################################
+## Enabe line below if chain supports cosmwasm  ##
+## module to properly build docker image        ##
+##################################################
+#RUN LINK_STATICALLY=true BUILD_TAGS="muslc" make build
+
+
 FROM alpine:latest
+##################################################
+## Enabe line below if chain supports cosmwasm  ##
+## module to properly build docker image        ##
+##################################################
+#RUN apk update && apk add --no-cache ca-certificates build-base
 WORKDIR /bdjuno
 COPY --from=builder /go/src/github.com/forbole/bdjuno/build/bdjuno /usr/bin/bdjuno
 CMD [ "bdjuno" ]

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,14 @@ LD_FLAGS = -X github.com/forbole/juno/v3/cmd.Version=$(VERSION) \
 	-X github.com/forbole/juno/v3/cmd.Commit=$(COMMIT)
 BUILD_FLAGS :=  -ldflags '$(LD_FLAGS)'
 
+ifeq ($(LINK_STATICALLY),true)
+  LD_FLAGS += -linkmode=external -extldflags "-Wl,-z,muldefs -static"
+endif
+
+build_tags += $(BUILD_TAGS)
+build_tags := $(strip $(build_tags))
+
+BUILD_FLAGS :=  -ldflags '$(LD_FLAGS)' -tags "$(build_tags)"
 
 ###############################################################################
 ###                                  Build                                  ###


### PR DESCRIPTION
## Description
The current Dockerfile does not support building bdjuno for chains that have CosmWasm. The commit first modifies the Makefile to accept BUILD_TAGS and LINK_STATICALLY parameters. Then Dockerfile includes both CosmWasm/non-CosmWasm version so that we can adjust it for each chain. 
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)