### PR TITLE
feat: remove block height foreign key from propoval vote and deposit, add timestamp column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 #### Gov Module
 - ([\#461](https://github.com/forbole/bdjuno/pull/461)) Parse `x/gov` genesis with `genesisDoc.InitialHeight` instead of the hard-coded height 1
 - ([\#465](https://github.com/forbole/bdjuno/pull/465)) Get open proposal ids in deposit or voting period by block time instead of current time
-- ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables
+- ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables and add column timestamp
 
 #### Daily refetch
 - ([\#454](https://github.com/forbole/bdjuno/pull/454)) Added `daily refetch` module to refetch missing blocks every day

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 ## Unreleased
 ### Changes
 
-#### Gov Module
-- ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables
-
 #### Upgrade Module
 - ([\#467](https://github.com/forbole/bdjuno/pull/467)) Store software upgrade plan and refresh data at upgrade height
-
 
 #### Staking Module
 - ([\#443](https://github.com/forbole/bdjuno/pull/443)) Remove tombstone status from staking module(already stored in slashing module)
@@ -15,6 +11,7 @@
 #### Gov Module
 - ([\#461](https://github.com/forbole/bdjuno/pull/461)) Parse `x/gov` genesis with `genesisDoc.InitialHeight` instead of the hard-coded height 1
 - ([\#465](https://github.com/forbole/bdjuno/pull/465)) Get open proposal ids in deposit or voting period by block time instead of current time
+- ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables
 
 #### Daily refetch
 - ([\#454](https://github.com/forbole/bdjuno/pull/454)) Added `daily refetch` module to refetch missing blocks every day

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 ### Changes
+
+#### Gov Module
+- ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables
+
 #### Upgrade Module
 - ([\#467](https://github.com/forbole/bdjuno/pull/467)) Store software upgrade plan and refresh data at upgrade height
 

--- a/database/schema/08-gov.sql
+++ b/database/schema/08-gov.sql
@@ -30,6 +30,7 @@ CREATE TABLE proposal_deposit
     proposal_id       INTEGER NOT NULL REFERENCES proposal (id),
     depositor_address TEXT             REFERENCES account (address),
     amount            COIN[],
+    timestamp         TIMESTAMP,
     height            BIGINT  NOT NULL,
     CONSTRAINT unique_deposit UNIQUE (proposal_id, depositor_address)
 );
@@ -42,6 +43,7 @@ CREATE TABLE proposal_vote
     proposal_id   INTEGER NOT NULL REFERENCES proposal (id),
     voter_address TEXT    NOT NULL REFERENCES account (address),
     option        TEXT    NOT NULL,
+    timestamp     TIMESTAMP,
     height        BIGINT  NOT NULL,
     CONSTRAINT unique_vote UNIQUE (proposal_id, voter_address)
 );

--- a/database/schema/08-gov.sql
+++ b/database/schema/08-gov.sql
@@ -30,7 +30,7 @@ CREATE TABLE proposal_deposit
     proposal_id       INTEGER NOT NULL REFERENCES proposal (id),
     depositor_address TEXT             REFERENCES account (address),
     amount            COIN[],
-    height            BIGINT  NOT NULL REFERENCES block (height),
+    height            BIGINT  NOT NULL,
     CONSTRAINT unique_deposit UNIQUE (proposal_id, depositor_address)
 );
 CREATE INDEX proposal_deposit_proposal_id_index ON proposal_deposit (proposal_id);
@@ -42,7 +42,7 @@ CREATE TABLE proposal_vote
     proposal_id   INTEGER NOT NULL REFERENCES proposal (id),
     voter_address TEXT    NOT NULL REFERENCES account (address),
     option        TEXT    NOT NULL,
-    height        BIGINT  NOT NULL REFERENCES block (height),
+    height        BIGINT  NOT NULL,
     CONSTRAINT unique_vote UNIQUE (proposal_id, voter_address)
 );
 CREATE INDEX proposal_vote_proposal_id_index ON proposal_vote (proposal_id);

--- a/database/types/gov.go
+++ b/database/types/gov.go
@@ -118,10 +118,11 @@ func (w TallyResultRow) Equals(v TallyResultRow) bool {
 
 // VoteRow represents a single row inside the vote table
 type VoteRow struct {
-	ProposalID int64  `db:"proposal_id"`
-	Voter      string `db:"voter_address"`
-	Option     string `db:"option"`
-	Height     int64  `db:"height"`
+	ProposalID int64     `db:"proposal_id"`
+	Voter      string    `db:"voter_address"`
+	Option     string    `db:"option"`
+	Timestamp  time.Time `db:"timestamp"`
+	Height     int64     `db:"height"`
 }
 
 // NewVoteRow allows to easily create a new VoteRow
@@ -129,12 +130,14 @@ func NewVoteRow(
 	proposalID int64,
 	voter string,
 	option string,
+	timestamp time.Time,
 	height int64,
 ) VoteRow {
 	return VoteRow{
 		ProposalID: proposalID,
 		Voter:      voter,
 		Option:     option,
+		Timestamp:  timestamp,
 		Height:     height,
 	}
 }
@@ -144,15 +147,17 @@ func (w VoteRow) Equals(v VoteRow) bool {
 	return w.ProposalID == v.ProposalID &&
 		w.Voter == v.Voter &&
 		w.Option == v.Option &&
+		w.Timestamp.Equal(v.Timestamp) &&
 		w.Height == v.Height
 }
 
 // DepositRow represents a single row inside the deposit table
 type DepositRow struct {
-	ProposalID int64   `db:"proposal_id"`
-	Depositor  string  `db:"depositor_address"`
-	Amount     DbCoins `db:"amount"`
-	Height     int64   `db:"height"`
+	ProposalID int64     `db:"proposal_id"`
+	Depositor  string    `db:"depositor_address"`
+	Amount     DbCoins   `db:"amount"`
+	Timestamp  time.Time `db:"timestamp"`
+	Height     int64     `db:"height"`
 }
 
 // NewDepositRow allows to easily create a new NewDepositRow
@@ -160,12 +165,14 @@ func NewDepositRow(
 	proposalID int64,
 	depositor string,
 	amount DbCoins,
+	timestamp time.Time,
 	height int64,
 ) DepositRow {
 	return DepositRow{
 		ProposalID: proposalID,
 		Depositor:  depositor,
 		Amount:     amount,
+		Timestamp:  timestamp,
 		Height:     height,
 	}
 }
@@ -175,6 +182,7 @@ func (w DepositRow) Equals(v DepositRow) bool {
 	return w.ProposalID == v.ProposalID &&
 		w.Depositor == v.Depositor &&
 		w.Amount.Equal(&v.Amount) &&
+		w.Timestamp.Equal(v.Timestamp) &&
 		w.Height == v.Height
 }
 

--- a/hasura/metadata/databases/bdjuno/tables/public_proposal_deposit.yaml
+++ b/hasura/metadata/databases/bdjuno/tables/public_proposal_deposit.yaml
@@ -24,6 +24,7 @@ select_permissions:
     - proposal_id
     - depositor_address
     - amount
+    - timestamp
     - height
     filter: {}
   role: anonymous

--- a/hasura/metadata/databases/bdjuno/tables/public_proposal_vote.yaml
+++ b/hasura/metadata/databases/bdjuno/tables/public_proposal_vote.yaml
@@ -7,7 +7,13 @@ object_relationships:
     foreign_key_constraint_on: voter_address
 - name: block
   using:
-    foreign_key_constraint_on: height
+    manual_configuration:
+      column_mapping:
+        height: height
+      insertion_order: null
+      remote_table:
+        name: block
+        schema: public
 - name: proposal
   using:
     foreign_key_constraint_on: proposal_id

--- a/hasura/metadata/databases/bdjuno/tables/public_proposal_vote.yaml
+++ b/hasura/metadata/databases/bdjuno/tables/public_proposal_vote.yaml
@@ -24,6 +24,7 @@ select_permissions:
     - proposal_id
     - voter_address
     - option
+    - timestamp
     - height
     filter: {}
   role: anonymous

--- a/modules/gov/handle_genesis.go
+++ b/modules/gov/handle_genesis.go
@@ -24,7 +24,7 @@ func (m *Module) HandleGenesis(doc *tmtypes.GenesisDoc, appState map[string]json
 	}
 
 	// Save the proposals
-	err = m.saveProposals(genState.Proposals, doc.InitialHeight)
+	err = m.saveProposals(genState.Proposals, doc)
 	if err != nil {
 		return fmt.Errorf("error while storing genesis governance proposals: %s", err)
 	}
@@ -44,7 +44,7 @@ func (m *Module) HandleGenesis(doc *tmtypes.GenesisDoc, appState map[string]json
 }
 
 // saveProposals save proposals from genesis file
-func (m *Module) saveProposals(slice govtypes.Proposals, genHeight int64) error {
+func (m *Module) saveProposals(slice govtypes.Proposals, genDoc *tmtypes.GenesisDoc) error {
 	proposals := make([]types.Proposal, len(slice))
 	tallyResults := make([]types.TallyResult, len(slice))
 	deposits := make([]types.Deposit, len(slice))
@@ -70,14 +70,15 @@ func (m *Module) saveProposals(slice govtypes.Proposals, genHeight int64) error 
 			proposal.FinalTallyResult.Abstain.String(),
 			proposal.FinalTallyResult.No.String(),
 			proposal.FinalTallyResult.NoWithVeto.String(),
-			genHeight,
+			genDoc.InitialHeight,
 		)
 
 		deposits[index] = types.NewDeposit(
 			proposal.ProposalId,
 			"",
 			proposal.TotalDeposit,
-			genHeight,
+			genDoc.GenesisTime,
+			genDoc.InitialHeight,
 		)
 	}
 

--- a/modules/gov/handle_msg.go
+++ b/modules/gov/handle_msg.go
@@ -2,6 +2,7 @@ package gov
 
 import (
 	"fmt"
+	"time"
 
 	"strconv"
 
@@ -74,8 +75,13 @@ func (m *Module) handleMsgSubmitProposal(tx *juno.Tx, index int, msg *govtypes.M
 		return err
 	}
 
+	txTimestamp, err := time.Parse(time.RFC3339, tx.Timestamp)
+	if err != nil {
+		return fmt.Errorf("error while parsing time: %s", err)
+	}
+
 	// Store the deposit
-	deposit := types.NewDeposit(proposal.ProposalId, msg.Proposer, msg.InitialDeposit, tx.Height)
+	deposit := types.NewDeposit(proposal.ProposalId, msg.Proposer, msg.InitialDeposit, txTimestamp, tx.Height)
 	return m.db.SaveDeposits([]types.Deposit{deposit})
 }
 
@@ -86,13 +92,24 @@ func (m *Module) handleMsgDeposit(tx *juno.Tx, msg *govtypes.MsgDeposit) error {
 		return fmt.Errorf("error while getting proposal deposit: %s", err)
 	}
 
+	txTimestamp, err := time.Parse(time.RFC3339, tx.Timestamp)
+	if err != nil {
+		return fmt.Errorf("error while parsing time: %s", err)
+	}
+
 	return m.db.SaveDeposits([]types.Deposit{
-		types.NewDeposit(msg.ProposalId, msg.Depositor, deposit.Amount, tx.Height),
+		types.NewDeposit(msg.ProposalId, msg.Depositor, deposit.Amount, txTimestamp, tx.Height),
 	})
 }
 
 // handleMsgVote allows to properly handle a handleMsgVote
 func (m *Module) handleMsgVote(tx *juno.Tx, msg *govtypes.MsgVote) error {
-	vote := types.NewVote(msg.ProposalId, msg.Voter, msg.Option, tx.Height)
+	txTimestamp, err := time.Parse(time.RFC3339, tx.Timestamp)
+	if err != nil {
+		return fmt.Errorf("error while parsing time: %s", err)
+	}
+
+	vote := types.NewVote(msg.ProposalId, msg.Voter, msg.Option, txTimestamp, tx.Height)
+
 	return m.db.SaveVote(vote)
 }

--- a/types/gov.go
+++ b/types/gov.go
@@ -156,6 +156,7 @@ type Deposit struct {
 	ProposalID uint64
 	Depositor  string
 	Amount     sdk.Coins
+	Timestamp  time.Time
 	Height     int64
 }
 
@@ -164,12 +165,14 @@ func NewDeposit(
 	proposalID uint64,
 	depositor string,
 	amount sdk.Coins,
+	timestamp time.Time,
 	height int64,
 ) Deposit {
 	return Deposit{
 		ProposalID: proposalID,
 		Depositor:  depositor,
 		Amount:     amount,
+		Timestamp:  timestamp,
 		Height:     height,
 	}
 }
@@ -181,6 +184,7 @@ type Vote struct {
 	ProposalID uint64
 	Voter      string
 	Option     govtypes.VoteOption
+	Timestamp  time.Time
 	Height     int64
 }
 
@@ -189,12 +193,14 @@ func NewVote(
 	proposalID uint64,
 	voter string,
 	option govtypes.VoteOption,
+	timestamp time.Time,
 	height int64,
 ) Vote {
 	return Vote{
 		ProposalID: proposalID,
 		Voter:      voter,
 		Option:     option,
+		Timestamp:  timestamp,
 		Height:     height,
 	}
 }


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

block height foreign key on `proposal_vote` and `proposal_deposit` tables is getting `parse genesis-file` errors because the block table could be empty at the time of parsing genesis. It results in the error like `pq: insert or update on table "proposal_deposit" violates foreign key constraint "proposal_deposit_height_fkey"`

Add `timestamp` column so frontend can access this data. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)