### PR TITLE
feat: add docker.io registry url to to FROM statements in Dockerfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 ### Dependencies
 - ([\#462](https://github.com/forbole/bdjuno/pull/462)) Updated Juno to `v3.4.0`
 
+### Dockerfiles
+- ([\#531](https://github.com/forbole/bdjuno/pull/531)) Add docker.io registry url to to FROM statements in Dockerfiles
+
 ## Version v3.2.0
 ### Changes
 #### Mint module

--- a/Dockerfile.cosmwasm
+++ b/Dockerfile.cosmwasm
@@ -1,6 +1,6 @@
 
 
-FROM golang:1.18-alpine AS builder
+FROM docker.io/golang:1.18-alpine AS builder
 RUN apk update && apk add --no-cache make git
 WORKDIR /go/src/github.com/forbole/bdjuno
 COPY . ./
@@ -15,7 +15,7 @@ RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
 RUN go mod download
 RUN LINK_STATICALLY=true BUILD_TAGS="muslc" make build
 
-FROM alpine:latest
+FROM docker.io/alpine:latest
 RUN apk update && apk add --no-cache ca-certificates build-base
 WORKDIR /bdjuno
 COPY --from=builder /go/src/github.com/forbole/bdjuno/build/bdjuno /usr/bin/bdjuno

--- a/Dockerfile.default
+++ b/Dockerfile.default
@@ -1,11 +1,11 @@
-FROM golang:1.18-alpine AS builder
+FROM docker.io/golang:1.18-alpine AS builder
 RUN apk update && apk add --no-cache make git
 WORKDIR /go/src/github.com/forbole/bdjuno
 COPY . ./
 RUN go mod download
 RUN make build
 
-FROM alpine:latest
+FROM docker.io/alpine:latest
 WORKDIR /bdjuno
 COPY --from=builder /go/src/github.com/forbole/bdjuno/build/bdjuno /usr/bin/bdjuno
 CMD [ "bdjuno" ]


### PR DESCRIPTION
## Description

Adding the docker.io registry URL to FROM statements in Dockerfiles enables building the container with other tools like [buildah](https://buildah.io/), that are not using docker.io as a default registry like Docker.

This is a non-breaking change and building the container with Docker will continue to work when this PR is merged.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change (change is non-breaking)
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc) (not needed IMO)
- [x] updated the relevant documentation or specification (not needed IMO)
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)