### PR TITLE
fix: add x/gov module proposal status change from deposit to voting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ This version is thought to be used with Cosmos SDK `v0.47.x`.
 - ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables and add column timestamp
 - ([\#499](https://github.com/forbole/bdjuno/pull/499)) Check if proposal has passed voting end time before marking it invalid
 - ([\#523](https://github.com/forbole/bdjuno/pull/523)) Update proposal snapshots handling on block
-
+- ([\#680](https://github.com/forbole/bdjuno/pull/523)) Handle proposal status change from deposit to voting
+- 
 #### Daily refetch
 - ([\#454](https://github.com/forbole/bdjuno/pull/454)) Added `daily refetch` module to refetch missing blocks every day
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This version is thought to be used with Cosmos SDK `v0.47.x`.
 - ([\#489](https://github.com/forbole/bdjuno/pull/489)) Remove block height foreign key from proposal_vote and proposal_deposit tables and add column timestamp
 - ([\#499](https://github.com/forbole/bdjuno/pull/499)) Check if proposal has passed voting end time before marking it invalid
 - ([\#523](https://github.com/forbole/bdjuno/pull/523)) Update proposal snapshots handling on block
-- ([\#680](https://github.com/forbole/bdjuno/pull/523)) Handle proposal status change from deposit to voting
+- ([\#681](https://github.com/forbole/bdjuno/pull/681)) Handle proposal status change from deposit to voting
 - 
 #### Daily refetch
 - ([\#454](https://github.com/forbole/bdjuno/pull/454)) Added `daily refetch` module to refetch missing blocks every day

--- a/modules/gov/handle_block.go
+++ b/modules/gov/handle_block.go
@@ -16,10 +16,10 @@ import (
 
 // HandleBlock implements modules.BlockModule
 func (m *Module) HandleBlock(
-	b *tmctypes.ResultBlock, blockResults *tmctypes.ResultBlockResults, _ []*juno.Tx, _ *tmctypes.ResultValidators,
+	b *tmctypes.ResultBlock, blockResults *tmctypes.ResultBlockResults, txs []*juno.Tx, _ *tmctypes.ResultValidators,
 ) error {
-
-	err := m.updateProposalsStatus(b.Block.Height, blockResults.EndBlockEvents)
+	txEvents := collectTxEvents(txs)
+	err := m.updateProposalsStatus(b.Block.Height, txEvents, blockResults.EndBlockEvents)
 	if err != nil {
 		log.Error().Str("module", "gov").Int64("height", b.Block.Height).
 			Err(err).Msg("error while updating proposals")
@@ -28,35 +28,23 @@ func (m *Module) HandleBlock(
 	return nil
 }
 
-// updateProposalsStatus updates the status of proposals if they have been included in the EndBlockEvents
-func (m *Module) updateProposalsStatus(height int64, events []abci.Event) error {
-	if len(events) == 0 {
-		return nil
-	}
-
+// updateProposalsStatus updates the status of proposals if they have been included in the EndBlockEvents or status
+// was changed from deposit to voting
+func (m *Module) updateProposalsStatus(height int64, txEvents, endBlockEvents []abci.Event) error {
 	var ids []uint64
 	// check if EndBlockEvents contains active_proposal event
-	eventsList := juno.FindEventsByType(events, govtypes.EventTypeActiveProposal)
-	if len(eventsList) == 0 {
-		return nil
+	endBlockIDs, err := findProposalIDsInEvents(endBlockEvents, govtypes.EventTypeActiveProposal, govtypes.AttributeKeyProposalID)
+	if err != nil {
+		return err
 	}
+	ids = append(ids, endBlockIDs...)
 
-	for _, event := range eventsList {
-		// find proposal ID
-		proposalID, err := juno.FindAttributeByKey(event, govtypes.AttributeKeyProposalID)
-		if err != nil {
-			return fmt.Errorf("error while getting proposal ID from block events: %s", err)
-		}
-
-		// parse proposal ID from []byte to unit64
-		id, err := strconv.ParseUint(proposalID.Value, 10, 64)
-		if err != nil {
-			return fmt.Errorf("error while parsing proposal id: %s", err)
-		}
-
-		// add proposal ID to ids array
-		ids = append(ids, id)
+	// the proposal changes state from the deposit to voting
+	txIDs, err := findProposalIDsInEvents(txEvents, govtypes.EventTypeProposalDeposit, govtypes.AttributeKeyVotingPeriodStart)
+	if err != nil {
+		return err
 	}
+	ids = append(ids, txIDs...)
 
 	// update status for proposals IDs stored in ids array
 	for _, id := range ids {
@@ -67,4 +55,38 @@ func (m *Module) updateProposalsStatus(height int64, events []abci.Event) error 
 	}
 
 	return nil
+}
+
+func findProposalIDsInEvents(events []abci.Event, eventType, attrKey string) ([]uint64, error) {
+	ids := make([]uint64, 0)
+	for _, event := range events {
+		if event.Type != eventType {
+			continue
+		}
+		for _, attr := range event.Attributes {
+			if attr.Key != attrKey {
+				continue
+			}
+			// parse proposal ID from []byte to unit64
+			id, err := strconv.ParseUint(attr.Value, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("error while parsing proposal id: %s", err)
+			}
+			// add proposal ID to ids array
+			ids = append(ids, id)
+		}
+	}
+
+	return ids, nil
+}
+
+func collectTxEvents(txs []*juno.Tx) []abci.Event {
+	events := make([]abci.Event, 0)
+	for _, tx := range txs {
+		for _, ev := range tx.Events {
+			events = append(events, abci.Event{Type: ev.Type, Attributes: ev.Attributes})
+		}
+	}
+
+	return events
 }


### PR DESCRIPTION
## Description

Currently the bdjuno doesn't cover the proposal status change from the deposit to voting. If a user creates a proposal with a minimum deposit the proposal has the status `deposit`. Later if a user adds more deposit to activate voting, the bdjuno doesn't change the proposals's state, and it remains `deposit`, however, the correct state is voting. The PR contains changes to update the state of the proposal if the block tx events contain proper events.

Cosmos SDK ref: https://github.com/cosmos/cosmos-sdk/blob/release/v0.47.x/x/gov/keeper/msg_server.go#L182 

Resolves: #680 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch
- [x] provided a link to the relevant issue or specification
- [x] added a changelog entry to `CHANGELOG.md`
- [x] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)