### PR TITLE
fix: replace message related to json into JSON type from JSONB

### DIFF
--- a/database/schema/00-cosmos.sql
+++ b/database/schema/00-cosmos.sql
@@ -43,7 +43,7 @@ CREATE TABLE transaction
     success      BOOLEAN NOT NULL,
 
     /* Body */
-    messages     JSONB   NOT NULL DEFAULT '[]'::JSONB,
+    messages     JSON    NOT NULL DEFAULT '[]'::JSON,
     memo         TEXT,
     signatures   TEXT[]  NOT NULL,
 
@@ -81,7 +81,7 @@ CREATE TABLE message
     transaction_hash            TEXT   NOT NULL,
     index                       BIGINT NOT NULL,
     type                        TEXT   NOT NULL REFERENCES message_type(type),
-    value                       JSONB  NOT NULL,
+    value                       JSON   NOT NULL,
     involved_accounts_addresses TEXT[] NOT NULL,
 
     /* PSQL partition */


### PR DESCRIPTION
## Description

This PR intends to fix the issue that message JSON may includes invalid Unicode sequence \u0000, it would cause the error when saving transactions and messages into Database.

Reference:
Invalid unicode sequence on PostgreSQL
Jackal transaction including invalid unicode sequence

Related issue: https://github.com/forbole/juno/pull/114

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)