### PR TITLE
fix: re-add support for gov v1beta1 messages

### DIFF
--- a/cmd/parse/gov/proposal.go
+++ b/cmd/parse/gov/proposal.go
@@ -125,17 +125,13 @@ func refreshProposalDetails(parseCtx *parser.Context, proposalID uint64, govModu
 
 	// Handle the MsgSubmitProposal messages
 	for index, msg := range tx.GetMsgs() {
-		_, isMsgSubmitProposalV1 := msg.(*govtypesv1.MsgSubmitProposal)
-		_, isMsgSubmitProposalV1Beta1 := msg.(*govtypesv1beta1.MsgSubmitProposal)
 
-		// Skip if the message is not a submit proposal message
-		if !isMsgSubmitProposalV1 && !isMsgSubmitProposalV1Beta1 {
-			continue
-		}
-
-		err = govModule.HandleMsg(index, msg, tx)
-		if err != nil {
-			return fmt.Errorf("error while handling MsgSubmitProposal: %s", err)
+		switch msg.(type) {
+		case *govtypesv1.MsgSubmitProposal, *govtypesv1beta1.MsgSubmitProposal:
+			err = govModule.HandleMsg(index, msg, tx)
+			if err != nil {
+				return fmt.Errorf("error while handling MsgSubmitProposal: %s", err)
+			}
 		}
 	}
 
@@ -160,17 +156,12 @@ func refreshProposalDeposits(parseCtx *parser.Context, proposalID uint64, govMod
 
 		// Handle the MsgDeposit messages
 		for index, msg := range junoTx.GetMsgs() {
-			_, isMsgDepositV1beta1 := msg.(*govtypesv1beta1.MsgDeposit)
-			_, isMsgDepositV1 := msg.(*govtypesv1.MsgDeposit)
-
-			// Skip if the message is not a deposit message
-			if !isMsgDepositV1 && !isMsgDepositV1beta1 {
-				continue
-			}
-
-			err = govModule.HandleMsg(index, msg, junoTx)
-			if err != nil {
-				return fmt.Errorf("error while handling MsgDeposit: %s", err)
+			switch msg.(type) {
+			case *govtypesv1.MsgDeposit, *govtypesv1beta1.MsgDeposit:
+				err = govModule.HandleMsg(index, msg, junoTx)
+				if err != nil {
+					return fmt.Errorf("error while handling MsgDeposit: %s", err)
+				}
 			}
 		}
 	}

--- a/cmd/parse/gov/proposal.go
+++ b/cmd/parse/gov/proposal.go
@@ -124,7 +124,11 @@ func refreshProposalDetails(parseCtx *parser.Context, proposalID uint64, govModu
 
 	// Handle the MsgSubmitProposal messages
 	for index, msg := range tx.GetMsgs() {
-		if _, ok := msg.(*govtypesv1.MsgSubmitProposal); !ok {
+		_, isMsgSubmitProposalV1 := msg.(*govtypesv1.MsgSubmitProposal)
+		_, isMsgSubmitProposalV1Beta1 := msg.(*govtypesv1beta1.MsgSubmitProposal)
+
+		// Skip if the message is not a submit proposal message
+		if !isMsgSubmitProposalV1 && !isMsgSubmitProposalV1Beta1 {
 			continue
 		}
 
@@ -155,7 +159,11 @@ func refreshProposalDeposits(parseCtx *parser.Context, proposalID uint64, govMod
 
 		// Handle the MsgDeposit messages
 		for index, msg := range junoTx.GetMsgs() {
-			if _, ok := msg.(*govtypesv1.MsgDeposit); !ok {
+			_, isMsgDepositV1beta1 := msg.(*govtypesv1beta1.MsgDeposit)
+			_, isMsgDepositV1 := msg.(*govtypesv1.MsgDeposit)
+
+			// Skip if the message is not a deposit message
+			if !isMsgDepositV1 && !isMsgDepositV1beta1 {
 				continue
 			}
 
@@ -187,7 +195,13 @@ func refreshProposalVotes(parseCtx *parser.Context, proposalID uint64, govModule
 
 		// Handle the MsgVote messages
 		for index, msg := range junoTx.GetMsgs() {
-			if msgVote, ok := msg.(*govtypesv1.MsgVote); !ok {
+			_, isMsgVoteV1 := msg.(*govtypesv1.MsgVote)
+			_, isMsgVoteV1Beta1 := msg.(*govtypesv1beta1.MsgVote)
+			_, isMsgVoteWeightedV1 := msg.(*govtypesv1.MsgVoteWeighted)
+			_, isMsgVoteWeightedV1Beta1 := msg.(*govtypesv1beta1.MsgVoteWeighted)
+
+			// Skip if the message is not a vote message
+			if !isMsgVoteV1 && !isMsgVoteV1Beta1 && !isMsgVoteWeightedV1 && !isMsgVoteWeightedV1Beta1 {
 				continue
 			} else {
 				// check if requested proposal ID is the same as proposal ID returned

--- a/modules/gov/handle_msg.go
+++ b/modules/gov/handle_msg.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/forbole/bdjuno/v4/types"
+	"github.com/forbole/callisto/v4/types"
 	"google.golang.org/grpc/codes"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,7 +14,7 @@ import (
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 
-	juno "github.com/forbole/juno/v4/types"
+	juno "github.com/forbole/juno/v5/types"
 )
 
 // HandleMsgExec implements modules.AuthzMessageModule

--- a/modules/gov/module.go
+++ b/modules/gov/module.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	_ modules.Module        = &Module{}
-	_ modules.GenesisModule = &Module{}
-	_ modules.BlockModule   = &Module{}
-	_ modules.MessageModule = &Module{}
+	_ modules.Module             = &Module{}
+	_ modules.GenesisModule      = &Module{}
+	_ modules.BlockModule        = &Module{}
+	_ modules.MessageModule      = &Module{}
+	_ modules.AuthzMessageModule = &Module{}
 )
 
 // Module represent x/gov module

--- a/modules/gov/utils_events.go
+++ b/modules/gov/utils_events.go
@@ -1,0 +1,63 @@
+package gov
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	eventsutil "github.com/forbole/bdjuno/v4/utils/events"
+)
+
+// ProposalIDFromEvent returns the proposal id from the given events
+func ProposalIDFromEvents(events sdk.StringEvents) (uint64, error) {
+	for _, event := range events {
+		attribute, ok := eventsutil.FindAttributeByKey(event, govtypes.AttributeKeyProposalID)
+		if ok {
+			return strconv.ParseUint(attribute.Value, 10, 64)
+		}
+	}
+
+	return 0, fmt.Errorf("no proposal id found")
+}
+
+// VoteOptionFromEvents returns the vote option from the given events
+func VoteOptionFromEvents(events sdk.StringEvents) (govtypesv1.VoteOption, error) {
+	for _, event := range events {
+		attribute, ok := eventsutil.FindAttributeByKey(event, govtypes.AttributeKeyOption)
+		if ok {
+			return parseVoteOption(attribute.Value)
+		}
+	}
+
+	return 0, fmt.Errorf("no vote option found")
+}
+
+// parseVoteOption returns the vote option from the given string
+// option value in string could be 2 cases, for example:
+// 1. "{\"option\":1,\"weight\":\"1.000000000000000000\"}"
+// 2. "option:VOTE_OPTION_NO weight:\"1.000000000000000000\""
+func parseVoteOption(optionValue string) (govtypesv1.VoteOption, error) {
+	// try parse option value as json
+	type voteOptionJSON struct {
+		Option govtypesv1.VoteOption `json:"option"`
+	}
+	var voteOptionParsedJSON voteOptionJSON
+	err := json.Unmarshal([]byte(optionValue), &voteOptionParsedJSON)
+	if err == nil {
+		return voteOptionParsedJSON.Option, nil
+	}
+
+	// try parse option value as string
+	// option:VOTE_OPTION_NO weight:"1.000000000000000000"
+	voteOptionParsed := strings.Split(optionValue, " ")
+	voteOption, err := govtypesv1.VoteOptionFromString(strings.ReplaceAll(voteOptionParsed[0], "option:", ""))
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse vote option %s: %s", optionValue, err)
+	}
+
+	return voteOption, nil
+}

--- a/modules/gov/utils_events.go
+++ b/modules/gov/utils_events.go
@@ -9,7 +9,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
-	eventsutil "github.com/forbole/bdjuno/v4/utils/events"
+	eventsutil "github.com/forbole/callisto/v4/utils/events"
 )
 
 // ProposalIDFromEvent returns the proposal id from the given events

--- a/modules/gov/utils_events.go
+++ b/modules/gov/utils_events.go
@@ -41,14 +41,14 @@ func WeightVoteOptionFromEvents(events sdk.StringEvents) (govtypesv1.WeightedVot
 // 1. "{\"option\":1,\"weight\":\"1.000000000000000000\"}"
 // 2. "option:VOTE_OPTION_NO weight:\"1.000000000000000000\""
 func parseWeightVoteOption(optionValue string) (govtypesv1.WeightedVoteOption, error) {
-	// try parse option value as json
+	// try parse json option value
 	var weightedVoteOption govtypesv1.WeightedVoteOption
 	err := json.Unmarshal([]byte(optionValue), &weightedVoteOption)
 	if err == nil {
 		return weightedVoteOption, nil
 	}
 
-	// try parse option value as string
+	// try parse string option value
 	// option:VOTE_OPTION_NO weight:"1.000000000000000000"
 	voteOptionParsed := strings.Split(optionValue, " ")
 	if len(voteOptionParsed) != 2 {
@@ -60,7 +60,7 @@ func parseWeightVoteOption(optionValue string) (govtypesv1.WeightedVoteOption, e
 		return govtypesv1.WeightedVoteOption{}, fmt.Errorf("failed to parse vote option %s: %s", optionValue, err)
 	}
 	weight := strings.ReplaceAll(voteOptionParsed[1], "weight:", "")
-	weight = strings.ReplaceAll(weight, "\\", "")
+	weight = strings.ReplaceAll(weight, "\"", "")
 
 	return govtypesv1.WeightedVoteOption{Option: voteOption, Weight: weight}, nil
 }

--- a/modules/gov/utils_events_test.go
+++ b/modules/gov/utils_events_test.go
@@ -1,0 +1,71 @@
+package gov_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
+	govtypesv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	"github.com/forbole/callisto/v4/modules/gov"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWeightVoteOptionFromEvents(t *testing.T) {
+	tests := []struct {
+		name      string
+		events    sdk.StringEvents
+		expected  govtypesv1.WeightedVoteOption
+		shouldErr bool
+	}{
+		{
+			"json option from vote event returns properly",
+			sdk.StringEvents{
+				sdk.StringEvent{
+					Type: "vote",
+					Attributes: []sdk.Attribute{
+						sdk.NewAttribute(govtypes.AttributeKeyOption, "{\"option\":1,\"weight\":\"1.000000000000000000\"}"),
+					},
+				},
+			},
+			govtypesv1.WeightedVoteOption{Option: govtypesv1.OptionYes, Weight: "1.000000000000000000"},
+			false,
+		},
+		{
+			"string option from vote event returns properly",
+			sdk.StringEvents{
+				sdk.StringEvent{
+					Type: "vote",
+					Attributes: []sdk.Attribute{
+						sdk.NewAttribute(govtypes.AttributeKeyOption, "option:VOTE_OPTION_NO weight:\"1.000000000000000000\""),
+					},
+				},
+			},
+			govtypesv1.WeightedVoteOption{Option: govtypesv1.OptionNo, Weight: "1.000000000000000000"},
+			false,
+		},
+		{
+			"invalid option from vote event returns error",
+			sdk.StringEvents{
+				sdk.StringEvent{
+					Type: "vote",
+					Attributes: []sdk.Attribute{
+						sdk.NewAttribute("other", "value"),
+					},
+				},
+			},
+			govtypesv1.WeightedVoteOption{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := gov.WeightVoteOptionFromEvents(test.events)
+			if test.shouldErr {
+				require.Error(t, err)
+			} else {
+				require.Equal(t, test.expected, result)
+			}
+		})
+	}
+}

--- a/utils/events/events.go
+++ b/utils/events/events.go
@@ -1,0 +1,25 @@
+package events
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// FindEventByType returns the event with the given type
+func FindEventByType(events sdk.StringEvents, eventType string) (sdk.StringEvent, bool) {
+	for _, event := range events {
+		if event.Type == eventType {
+			return event, true
+		}
+	}
+	return sdk.StringEvent{}, false
+}
+
+// FindAttributeByKey returns the attribute with the given key
+func FindAttributeByKey(event sdk.StringEvent, key string) (sdk.Attribute, bool) {
+	for _, attribute := range event.Attributes {
+		if attribute.Key == key {
+			return attribute, true
+		}
+	}
+	return sdk.Attribute{}, false
+}


### PR DESCRIPTION
## Description

Closes: #XXXX
Currently, gov module is updated to gov v1, however, gov v1beta1 is still alive to chains, Cosmos-SDK doesn't completely remove v1beta1 support. As a result, we should re-add gov v1beta1 support to make sure our proposals data are also updated when gov v1beta1 messages are performed.

Say, some of users on Cheqd is using gov.v1beta1.MsgVote to vote on the proposal.
https://bigdipper.live/cheqd/transactions/19E4F068FBFBC46DA9BEF3E0F7CA908317D5582CAB2A17683138A5248ED34E3C

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)