### PR TITLE
fix: add missing proposal event type handling during update proposal status

### DIFF
--- a/modules/gov/handle_block.go
+++ b/modules/gov/handle_block.go
@@ -39,12 +39,19 @@ func (m *Module) updateProposalsStatus(height int64, txEvents, endBlockEvents []
 	}
 	ids = append(ids, endBlockIDs...)
 
-	// the proposal changes state from the deposit to voting
-	txIDs, err := findProposalIDsInEvents(txEvents, govtypes.EventTypeProposalDeposit, govtypes.AttributeKeyVotingPeriodStart)
+	// the proposal changes state from the submit to voting
+	idsInSubmitTxs, err := findProposalIDsInEvents(txEvents, govtypes.EventTypeSubmitProposal, govtypes.AttributeKeyVotingPeriodStart)
 	if err != nil {
 		return err
 	}
-	ids = append(ids, txIDs...)
+	ids = append(ids, idsInSubmitTxs...)
+
+	// the proposal changes state from the deposit to voting
+	idsInDepositTxs, err := findProposalIDsInEvents(txEvents, govtypes.EventTypeProposalDeposit, govtypes.AttributeKeyVotingPeriodStart)
+	if err != nil {
+		return err
+	}
+	ids = append(ids, idsInDepositTxs...)
 
 	// update status for proposals IDs stored in ids array
 	for _, id := range ids {


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR adds missing event handling when updating proposal status.
Reference: https://docs.cosmos.network/main/build/modules/gov#msgsubmitproposal

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch
- [ ] provided a link to the relevant issue or specification
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)